### PR TITLE
set state to avoid session_timeout removing running session

### DIFF
--- a/engine/services/engine_service_impl.cc
+++ b/engine/services/engine_service_impl.cc
@@ -243,7 +243,11 @@ void EngineServiceImpl::RunExecutionPlan(
 
   // 2. run jobs in plan and add result to response.
   try {
+    YACL_ENFORCE(session_mgr_->SetSessionState(session_id, SessionState::IDLE,
+                                               SessionState::RUNNING));
     RunPlan(*request, session, response);
+    YACL_ENFORCE(session_mgr_->SetSessionState(
+        session_id, SessionState::RUNNING, SessionState::IDLE));
   } catch (const std::exception& e) {
     std::string err_msg = fmt::format(
         "RunExecutionPlan run jobs({}) failed, catch std::exception={} ",


### PR DESCRIPTION
when  default session_timeout is small for large task, the sync task may failed: the session_time can clear the whole session.