### PR TITLE
在 SCQL 中实现单方算子 length

### DIFF
--- a/pkg/expression/expression_to_stmt.go
+++ b/pkg/expression/expression_to_stmt.go
@@ -139,7 +139,7 @@ func (c ExprConverter) convertScalarFunction(dialect format.Dialect, expr *Scala
 		return &ast.FuncCallExpr{FnName: expr.FuncName, Args: children}, nil
 	case ast.If:
 		return &ast.FuncCallExpr{FnName: expr.FuncName, Args: children}, nil
-	case ast.Cos, ast.Abs, ast.Round, ast.Log10, ast.Ceil, ast.Floor, ast.Instr:
+	case ast.Cos, ast.Abs, ast.Round, ast.Log10, ast.Ceil, ast.Floor, ast.Instr, ast.Length:
 		return &ast.FuncCallExpr{FnName: expr.FuncName, Args: children}, nil
 	}
 	switch expr.Function.(type) {

--- a/pkg/planner/core/testdata/runsql_in.json
+++ b/pkg/planner/core/testdata/runsql_in.json
@@ -341,6 +341,11 @@
         "rewritten_sql": "select floor(tbl_1.aggregate_float_0) as a from alice.tbl_1"
       },
       {
+        "sql": "select length(plain_string_0) as a from alice.tbl_1",
+        "skip_projection": false,
+        "rewritten_sql": "select length(tbl_1.plain_string_0) as a from alice.tbl_1"
+      },
+      {
         "sql": "select instr(plain_string_0, 'teststr') as a from alice.tbl_1",
         "skip_projection": false,
         "rewritten_sql": "select instr(tbl_1.plain_string_0, 'teststr') as a from alice.tbl_1"


### PR DESCRIPTION
#118 

添加测试样例
![image](https://github.com/secretflow/scql/assets/25099083/8b806ccc-7eb6-4347-97d5-31d10c84d109)

运行测试失败
![image](https://github.com/secretflow/scql/assets/25099083/d29d74d2-86e0-4527-bea1-7a6a12ba579c)

添加实现
![image](https://github.com/secretflow/scql/assets/25099083/f1d4bc6b-7954-47cf-82c8-ae591e2d730f)

运行测试成功
![image](https://github.com/secretflow/scql/assets/25099083/2ecbeb6a-4829-410d-aab1-014408207b89)
