### PR TITLE
feat: Implement the archive project API

### DIFF
--- a/cmd/brokerctl/cmd/archive.go
+++ b/cmd/brokerctl/cmd/archive.go
@@ -1,0 +1,41 @@
+// Copyright 2025 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var archiveCmd = &cobra.Command{
+	Use:   "archive project",
+	Short: "Archive an existing project",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return archiveProject()
+	},
+}
+
+func archiveProject() error {
+	if projectID == "" {
+		return fmt.Errorf("flags project-id must not be empty")
+	}
+	err := brokerCommand.ArchiveProject(projectID)
+	if err != nil {
+		return err
+	}
+	fmt.Println("archive project succeeded")
+	return nil
+}

--- a/cmd/brokerctl/cmd/archive.go
+++ b/cmd/brokerctl/cmd/archive.go
@@ -32,10 +32,11 @@ func archiveProject() error {
 	if projectID == "" {
 		return fmt.Errorf("flags project-id must not be empty")
 	}
-	err := brokerCommand.ArchiveProject(projectID)
+	msg, err := brokerCommand.ArchiveProject(projectID)
 	if err != nil {
 		return err
 	}
-	fmt.Println("archive project succeeded")
+
+	fmt.Println(msg)
 	return nil
 }

--- a/cmd/brokerctl/cmd/root.go
+++ b/cmd/brokerctl/cmd/root.go
@@ -56,6 +56,7 @@ func init() {
 	}
 
 	rootCmd.AddCommand(createCmd)
+	rootCmd.AddCommand(archiveCmd)
 	rootCmd.AddCommand(deleteCmd)
 	rootCmd.AddCommand(getCmd)
 	rootCmd.AddCommand(inviteCmd)

--- a/pkg/broker/application/intra_stub.go
+++ b/pkg/broker/application/intra_stub.go
@@ -67,6 +67,10 @@ func (stub *IntraStub) CreateProject(url string, req *pb.CreateProjectRequest, r
 	return stub.baseCall(url, constant.CreateProjectPath, req, response)
 }
 
+func (stub *IntraStub) ArchiveProject(url string, req *pb.ArchiveProjectRequest, response *pb.ArchiveProjectResponse) (err error) {
+	return stub.baseCall(url, constant.ArchiveProjectPath, req, response)
+}
+
 func (stub *IntraStub) ListProjects(url string, req *pb.ListProjectsRequest, response *pb.ListProjectsResponse) (err error) {
 	return stub.baseCall(url, constant.ListProjectsPath, req, response)
 }

--- a/pkg/broker/constant/constant.go
+++ b/pkg/broker/constant/constant.go
@@ -23,6 +23,7 @@ const (
 	CancelQueryPath          = "/intra/query/cancel"
 	ExplainQueryPath         = "/intra/query/explain"
 	CreateProjectPath        = "/intra/project/create"
+	ArchiveProjectPath       = "/intra/project/archive"
 	ListProjectsPath         = "/intra/project/list"
 	InviteMemberPath         = "/intra/member/invite"
 	ListInvitationsPath      = "/intra/invitation/list"

--- a/pkg/broker/server/server.go
+++ b/pkg/broker/server/server.go
@@ -50,6 +50,7 @@ func NewIntraServer(app *application.App) (*http.Server, error) {
 	router.POST(constant.ExplainQueryPath, intraSvc.ExplainQueryHandler)
 	router.POST(constant.CancelQueryPath, intraSvc.CancelQueryHandler)
 	router.POST(constant.CreateProjectPath, intraSvc.CreateProjectHandler)
+	router.POST(constant.ArchiveProjectPath, intraSvc.ArchiveProjectHandler)
 	router.POST(constant.ListProjectsPath, intraSvc.ListProjectsHandler)
 	router.POST(constant.InviteMemberPath, intraSvc.InviteMemberHandler)
 	router.POST(constant.ListInvitationsPath, intraSvc.ListInvitationsHandler)

--- a/pkg/broker/services/common/common.go
+++ b/pkg/broker/services/common/common.go
@@ -242,7 +242,7 @@ func ArchivedProjectErrorResponse[T any](opName, projectID string) (*T, bool) {
 	var resp T
 	status := &pb.Status{
 		Code:    int32(pb.Code_NOT_SUPPORTED),
-		Message: fmt.Sprintf("%s: project %v is archived", opName, projectID),
+		Message: fmt.Sprintf("%s: project %v is already archived", opName, projectID),
 	}
 	v := reflect.ValueOf(&resp).Elem().FieldByName("Status")
 	if !v.IsValid() {

--- a/pkg/broker/services/common/common.go
+++ b/pkg/broker/services/common/common.go
@@ -246,7 +246,7 @@ func ArchivedProjectErrorResponse[T any](opName, projectID string) (*T, bool) {
 	}
 	v := reflect.ValueOf(&resp).Elem().FieldByName("Status")
 	if !v.IsValid() {
-		panic("Response struct must have a Status field")
+		return nil, false
 	}
 	v.Set(reflect.ValueOf(status))
 	return &resp, true
@@ -261,7 +261,10 @@ func CheckProjectArchived[T any](
 		return nil, fmt.Errorf("%s: get project %v err: %v", opName, projectID, err)
 	}
 	if project.Archived {
-		resp, _ := ArchivedProjectErrorResponse[T](opName, projectID)
+		resp, valid := ArchivedProjectErrorResponse[T](opName, projectID)
+		if !valid {
+			return nil, fmt.Errorf("%s: Response struct must have a Status field", opName)
+		}
 		return resp, nil
 	}
 	return nil, nil

--- a/pkg/broker/services/common/common.go
+++ b/pkg/broker/services/common/common.go
@@ -255,14 +255,14 @@ func ArchivedProjectErrorResponse[T any](opName, projectID string) (*T, bool) {
 func CheckProjectArchived[T any](
 	txn *storage.MetaTransaction,
 	projectID, opName string,
-) (resp *T, shouldReturn bool, err error) {
+) (resp *T, err error) {
 	project, err := txn.GetProject(projectID)
 	if err != nil {
-		return nil, true, fmt.Errorf("%s: get project %v err: %v", opName, projectID, err)
+		return nil, fmt.Errorf("%s: get project %v err: %v", opName, projectID, err)
 	}
 	if project.Archived {
 		resp, _ := ArchivedProjectErrorResponse[T](opName, projectID)
-		return resp, true, nil
+		return resp, nil
 	}
-	return nil, false, nil
+	return nil, nil
 }

--- a/pkg/broker/services/common/storage_with_check.go
+++ b/pkg/broker/services/common/storage_with_check.go
@@ -159,7 +159,7 @@ func ArchiveProjectWithCheck(t *storage.MetaTransaction, project *storage.Projec
 	project.Archived = true
 	err = t.UpdateProject(*project)
 	if err != nil {
-		return fmt.Errorf("ArchiveProjectWithCheck: AddTable %v", err)
+		return fmt.Errorf("ArchiveProjectWithCheck: update project status error: %v", err)
 	}
 	return nil
 }

--- a/pkg/broker/services/common/storage_with_check.go
+++ b/pkg/broker/services/common/storage_with_check.go
@@ -147,6 +147,23 @@ func RevokeColumnConstraintsWithCheck(t *storage.MetaTransaction, projectID, par
 	return nil
 }
 
+func ArchiveProjectWithCheck(t *storage.MetaTransaction, project *storage.Project, party string) error {
+	members, err := t.GetProjectMembers(project.ID)
+	if err != nil {
+		return fmt.Errorf("ArchiveProjectWithCheck: GetProject %v", err)
+	}
+	if !slices.Contains(members, party) {
+		return fmt.Errorf("ArchiveProjectWithCheck: party %s is not in project %s", party, project.ID)
+	}
+
+	project.Archived = true
+	err = t.UpdateProject(*project)
+	if err != nil {
+		return fmt.Errorf("ArchiveProjectWithCheck: AddTable %v", err)
+	}
+	return nil
+}
+
 func AddTableWithCheck(t *storage.MetaTransaction, projectID, party string, table storage.TableMeta) error {
 	// check owner
 	if table.Table.Owner != party {

--- a/pkg/broker/services/inter/project_handler.go
+++ b/pkg/broker/services/inter/project_handler.go
@@ -106,6 +106,14 @@ func (svc *grpcInterSvc) ReplyInvitation(c context.Context, req *pb.ReplyInvitat
 	if err != nil {
 		return nil, fmt.Errorf("ReplyInvitation: %v", err)
 	}
+	if proj.Archived {
+		return &pb.ReplyInvitationResponse{
+			Status: &pb.Status{
+				Code:    int32(pb.Code_NOT_SUPPORTED),
+				Message: fmt.Sprintf("ProcessInvitation: project %v is already archived", proj.ID),
+			}}, nil
+	}
+
 	if proj.Creator != svc.app.Conf.PartyCode {
 		return nil, fmt.Errorf("ReplyInvitation: project %v not owned by self party %v", proj.ID, svc.app.Conf.PartyCode)
 	}

--- a/pkg/broker/services/inter/query_handler.go
+++ b/pkg/broker/services/inter/query_handler.go
@@ -44,6 +44,16 @@ func (svc *grpcInterSvc) DistributeQuery(ctx context.Context, req *pb.Distribute
 	}
 
 	app := svc.app
+	// check whether project is archived
+	txn := app.MetaMgr.CreateMetaTransaction()
+	defer func() {
+		err = txn.Finish(err)
+	}()
+	res, err = common.CheckProjectArchived[pb.DistributeQueryResponse](txn, req.GetProjectId(), "DistributeQuery")
+	if res != nil || err != nil {
+		return res, err
+	}
+
 	// 2. create session
 	if _, err := app.GetSessionInfo(req.JobId); err == nil {
 		errStr := fmt.Sprintf("DistributeQuery: already existing job for id %s, err: %v", req.JobId, err)

--- a/pkg/broker/services/inter/svc.go
+++ b/pkg/broker/services/inter/svc.go
@@ -53,6 +53,15 @@ func (svc *grpcInterSvc) SyncInfo(c context.Context, req *pb.SyncInfoRequest) (r
 
 	action := req.GetChangeEntry().GetAction()
 	switch action {
+	case pb.ChangeEntry_ArchiveProject:
+		proj, err := storage.AddShareLock(txn).GetProject(req.GetProjectId())
+		if err != nil {
+			return nil, fmt.Errorf("SyncInfo: get project %v err: %v", req.GetProjectId(), err)
+		}
+		err = common.ArchiveProjectWithCheck(txn, &proj, req.GetClientId().GetCode())
+		if err != nil {
+			return nil, fmt.Errorf("SyncInfo ArchiveProject: archive project %v err: %v", req.GetProjectId(), err)
+		}
 	case pb.ChangeEntry_AddProjectMember:
 		proj, err := storage.AddShareLock(txn).GetProject(req.GetProjectId())
 		if err != nil {

--- a/pkg/broker/services/intra/ccl_handler.go
+++ b/pkg/broker/services/intra/ccl_handler.go
@@ -40,6 +40,11 @@ func (svc *grpcIntraSvc) GrantCCL(ctx context.Context, req *pb.GrantCCLRequest) 
 		err = txn.Finish(err)
 	}()
 
+	resp, shouldReturn, err := common.CheckProjectArchived[pb.GrantCCLResponse](txn, req.GetProjectId(), "GrantCCL")
+	if shouldReturn {
+		return resp, err
+	}
+
 	members, err := txn.GetProjectMembers(req.GetProjectId())
 	if err != nil {
 		return nil, fmt.Errorf("GrantCCL: get project %s err: %v", req.GetProjectId(), err)
@@ -95,24 +100,30 @@ func (svc *grpcIntraSvc) RevokeCCL(c context.Context, req *pb.RevokeCCLRequest) 
 	if err != nil {
 		return nil, fmt.Errorf("RevokeCCL: %v", err)
 	}
+
 	app := svc.app
-	var members []string
-	err = app.MetaMgr.ExecInMetaTransaction(func(txn *storage.MetaTransaction) error {
-		var err error
-		err = common.RevokeColumnConstraintsWithCheck(txn, req.GetProjectId(), app.Conf.PartyCode, privIDs)
-		if err != nil {
-			return fmt.Errorf("RevokeCCL: %v", err)
-		}
-		// get sync parties
-		members, err = txn.GetProjectMembers(req.GetProjectId())
-		if err != nil {
-			return fmt.Errorf("RevokeCCL: GetProject: %v", err)
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
+	txn := app.MetaMgr.CreateMetaTransaction()
+	defer func() {
+		err = txn.Finish(err)
+	}()
+
+	resp, shouldReturn, err := common.CheckProjectArchived[pb.RevokeCCLResponse](txn, req.GetProjectId(), "RevokeCCL")
+	if shouldReturn {
+		return resp, err
 	}
+
+	err = common.RevokeColumnConstraintsWithCheck(txn, req.GetProjectId(), app.Conf.PartyCode, privIDs)
+	if err != nil {
+		return nil, fmt.Errorf("RevokeCCL: %v", err)
+	}
+
+	// get sync parties
+	var members []string
+	members, err = txn.GetProjectMembers(req.GetProjectId())
+	if err != nil {
+		return nil, fmt.Errorf("RevokeCCL: GetProject: %v", err)
+	}
+
 	// sync to other parties
 	go func() {
 		var targetParties []string
@@ -145,6 +156,12 @@ func (svc *grpcIntraSvc) ShowCCL(ctx context.Context, req *pb.ShowCCLRequest) (r
 	defer func() {
 		err = txn.Finish(err)
 	}()
+
+	resp, shouldReturn, err := common.CheckProjectArchived[pb.ShowCCLResponse](txn, req.GetProjectId(), "ShowCCL")
+	if shouldReturn {
+		return resp, err
+	}
+
 	// check project exist
 	projectAndMembers, err := txn.GetProjectAndMembers(req.GetProjectId())
 	if err != nil {

--- a/pkg/broker/services/intra/ccl_handler.go
+++ b/pkg/broker/services/intra/ccl_handler.go
@@ -40,8 +40,8 @@ func (svc *grpcIntraSvc) GrantCCL(ctx context.Context, req *pb.GrantCCLRequest) 
 		err = txn.Finish(err)
 	}()
 
-	resp, shouldReturn, err := common.CheckProjectArchived[pb.GrantCCLResponse](txn, req.GetProjectId(), "GrantCCL")
-	if shouldReturn {
+	resp, err = common.CheckProjectArchived[pb.GrantCCLResponse](txn, req.GetProjectId(), "GrantCCL")
+	if resp != nil || err != nil {
 		return resp, err
 	}
 
@@ -107,8 +107,8 @@ func (svc *grpcIntraSvc) RevokeCCL(c context.Context, req *pb.RevokeCCLRequest) 
 		err = txn.Finish(err)
 	}()
 
-	resp, shouldReturn, err := common.CheckProjectArchived[pb.RevokeCCLResponse](txn, req.GetProjectId(), "RevokeCCL")
-	if shouldReturn {
+	resp, err = common.CheckProjectArchived[pb.RevokeCCLResponse](txn, req.GetProjectId(), "RevokeCCL")
+	if resp != nil || err != nil {
 		return resp, err
 	}
 
@@ -157,8 +157,8 @@ func (svc *grpcIntraSvc) ShowCCL(ctx context.Context, req *pb.ShowCCLRequest) (r
 		err = txn.Finish(err)
 	}()
 
-	resp, shouldReturn, err := common.CheckProjectArchived[pb.ShowCCLResponse](txn, req.GetProjectId(), "ShowCCL")
-	if shouldReturn {
+	resp, err = common.CheckProjectArchived[pb.ShowCCLResponse](txn, req.GetProjectId(), "ShowCCL")
+	if resp != nil || err != nil {
 		return resp, err
 	}
 

--- a/pkg/broker/services/intra/handler_test.go
+++ b/pkg/broker/services/intra/handler_test.go
@@ -345,7 +345,7 @@ func (s *intraTestSuite) TestParameterCheck() {
 	listCCLsReq := &pb.ShowCCLRequest{ProjectId: "not_exist"}
 	_, err = s.svcAlice.ShowCCL(s.ctx, listCCLsReq)
 	s.Error(err)
-	s.Equal("ShowCCL: GetProjectAndMembers err: record not found", err.Error())
+	s.Equal("ShowCCL: get project not_exist err: record not found", err.Error())
 	listCCLsReq = &pb.ShowCCLRequest{ProjectId: "1", Tables: []string{"not_exist_table"}}
 	_, err = s.svcAlice.ShowCCL(s.ctx, listCCLsReq)
 	s.Error(err)
@@ -365,7 +365,7 @@ func (s *intraTestSuite) TestParameterCheck() {
 	grantCCLReq = &pb.GrantCCLRequest{ProjectId: "not_exist", ColumnControlList: []*pb.ColumnControl{&pb.ColumnControl{Col: &pb.ColumnDef{ColumnName: "not_exist_col", TableName: "not_exist_table"}, PartyCode: "alice", Constraint: 10}}}
 	_, err = s.svcAlice.GrantCCL(s.ctx, grantCCLReq)
 	s.Error(err)
-	s.Equal("GrantCCL: project not_exist has no members or project doesn't exist", err.Error())
+	s.Equal("GrantCCL: get project not_exist err: record not found", err.Error())
 	revokeCCLReq := &pb.RevokeCCLRequest{ProjectId: "1", ColumnControlList: []*pb.ColumnControl{&pb.ColumnControl{Col: &pb.ColumnDef{ColumnName: "not_exist_col", TableName: "not_exist_table"}, PartyCode: "alice"}}}
 	_, err = s.svcAlice.RevokeCCL(s.ctx, revokeCCLReq)
 	s.Error(err)

--- a/pkg/broker/services/intra/project_handler.go
+++ b/pkg/broker/services/intra/project_handler.go
@@ -208,7 +208,7 @@ func (svc *grpcIntraSvc) ArchiveProject(c context.Context, req *pb.ArchiveProjec
 		return nil, fmt.Errorf("ArchiveProject: failed to get project info in meta database: %v", err)
 	}
 
-	if project.Archived == true {
+	if project.Archived {
 		return &pb.ArchiveProjectResponse{
 			Status: &pb.Status{
 				Code:    int32(pb.Code_OK),

--- a/pkg/broker/services/intra/project_handler.go
+++ b/pkg/broker/services/intra/project_handler.go
@@ -45,15 +45,6 @@ func (svc *grpcIntraSvc) CreateProject(c context.Context, req *pb.CreateProjectR
 	}
 
 	app := svc.app
-	txn := app.MetaMgr.CreateMetaTransaction()
-	defer func() {
-		err = txn.Finish(err)
-	}()
-
-	resp, shouldReturn, err := common.CheckProjectArchived[pb.CreateProjectResponse](txn, req.GetProjectId(), "CreateProject")
-	if shouldReturn {
-		return resp, err
-	}
 
 	projectConf := req.GetConf()
 	if projectConf == nil {
@@ -125,18 +116,19 @@ func (svc *grpcIntraSvc) CreateProject(c context.Context, req *pb.CreateProjectR
 		return nil, fmt.Errorf("CreateProject: failed to veriry project ID: %v", err)
 	}
 
-	_, err = txn.GetProject(project.ID)
-	if err == nil {
-		return nil, fmt.Errorf("CreateProject: project %s already exists", project.ID)
-	}
-	if !errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, err
-	}
-	err = txn.CreateProject(project)
+	err = app.MetaMgr.ExecInMetaTransaction(func(txn *storage.MetaTransaction) error {
+		_, err := txn.GetProject(project.ID)
+		if err == nil {
+			return fmt.Errorf("CreateProject: project %s already exists", project.ID)
+		}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+		return txn.CreateProject(project)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("CreateProject: failed to create table in meta database: %v", err)
 	}
-
 	return &pb.CreateProjectResponse{
 		Status: &pb.Status{
 			Code:    int32(0),

--- a/pkg/broker/services/intra/project_handler.go
+++ b/pkg/broker/services/intra/project_handler.go
@@ -502,10 +502,6 @@ func (svc *grpcIntraSvc) ProcessInvitation(c context.Context, req *pb.ProcessInv
 	if err != nil {
 		return nil, fmt.Errorf("ProcessInvitation: GetUnhandledInvitationWithID: %v", err)
 	}
-	resp, shouldReturn, err := common.CheckProjectArchived[pb.ProcessInvitationResponse](txn, invitation.ProjectID, "ProcessInvitation")
-	if shouldReturn {
-		return resp, err
-	}
 	if invitation.Invitee != svc.app.Conf.PartyCode {
 		invalidInvitation = true
 		return nil, fmt.Errorf("ProcessInvitation: invitee{%v} != selfParty{%v}", invitation.Invitee, svc.app.Conf.PartyCode)

--- a/pkg/broker/services/intra/project_handler.go
+++ b/pkg/broker/services/intra/project_handler.go
@@ -182,7 +182,93 @@ func (svc *grpcIntraSvc) ListProjects(c context.Context, req *pb.ListProjectsReq
 }
 
 func (svc *grpcIntraSvc) ArchiveProject(c context.Context, req *pb.ArchiveProjectRequest) (resp *pb.ArchiveProjectResponse, err error) {
-	return nil, errors.New("method ArchiveProject not implemented")
+	if req == nil {
+		return nil, status.New(pb.Code_BAD_REQUEST, "ArchiveProject: illegal empty request")
+	}
+	if req.GetProjectId() == "" {
+		return nil, status.New(pb.Code_BAD_REQUEST, "ArchiveProject: project_id cannot be empty")
+	}
+
+	app := svc.app
+	txn := app.MetaMgr.CreateMetaTransaction()
+	defer func() {
+		err = txn.Finish(err)
+	}()
+
+	project, err := txn.GetProject(req.GetProjectId())
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return &pb.ArchiveProjectResponse{
+				Status: &pb.Status{
+					Code:    int32(pb.Code_NOT_FOUND),
+					Message: "project not found",
+				},
+			}, nil
+		}
+		return nil, fmt.Errorf("ArchiveProject: failed to get project info in meta database: %v", err)
+	}
+
+	if project.Archived == true {
+		return &pb.ArchiveProjectResponse{
+			Status: &pb.Status{
+				Code:    int32(pb.Code_OK),
+				Message: "project already archived",
+			},
+		}, nil
+	}
+
+	// Send archive project request to the project creator first.
+	// If it fails, immediately return archive failure.
+	err = common.PostSyncInfo(svc.app, req.GetProjectId(), pb.ChangeEntry_ArchiveProject, nil, []string{project.Creator})
+	if err != nil {
+		return nil, fmt.Errorf("ArchiveProject: failed to sync: %v", err)
+	}
+
+	project.Archived = true
+	err = txn.UpdateProject(project)
+	if err != nil {
+		return nil, fmt.Errorf("ArchiveProject: failed to update project: %v", err)
+	}
+
+	members, err := txn.GetProjectMembers(req.GetProjectId())
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return &pb.ArchiveProjectResponse{
+				Status: &pb.Status{
+					Code:    int32(pb.Code_NOT_FOUND),
+					Message: "project members not found",
+				},
+			}, nil
+		}
+		return nil, fmt.Errorf("ArchiveProject: failed to get project members info in meta database: %v", err)
+	}
+
+	var targetParties []string
+	for _, p := range members {
+		if p != app.Conf.PartyCode && p != project.Creator {
+			targetParties = append(targetParties, p)
+		}
+	}
+
+	err = common.PostSyncInfo(app, req.GetProjectId(), pb.ChangeEntry_ArchiveProject, nil, targetParties)
+	if err != nil {
+		// still need to archive project locally
+		err = nil
+		// some members need to execute CheckAndUpdateStatus
+		return &pb.ArchiveProjectResponse{
+			Status: &pb.Status{
+				Code:    int32(pb.Code_OK),
+				Message: "archive project is partially successful",
+			},
+		}, nil
+	}
+
+	return &pb.ArchiveProjectResponse{
+		Status: &pb.Status{
+			Code:    int32(pb.Code_OK),
+			Message: "archive project succeed",
+		},
+	}, nil
 }
 
 func (svc *grpcIntraSvc) InviteMember(c context.Context, req *pb.InviteMemberRequest) (resp *pb.InviteMemberResponse, err error) {

--- a/pkg/broker/services/intra/project_handler.go
+++ b/pkg/broker/services/intra/project_handler.go
@@ -219,9 +219,11 @@ func (svc *grpcIntraSvc) ArchiveProject(c context.Context, req *pb.ArchiveProjec
 
 	// Send archive project request to the project creator first.
 	// If it fails, immediately return archive failure.
-	err = common.PostSyncInfo(svc.app, req.GetProjectId(), pb.ChangeEntry_ArchiveProject, nil, []string{project.Creator})
-	if err != nil {
-		return nil, fmt.Errorf("ArchiveProject: failed to sync: %v", err)
+	if app.Conf.PartyCode != project.Creator {
+		err = common.PostSyncInfo(svc.app, req.GetProjectId(), pb.ChangeEntry_ArchiveProject, nil, []string{project.Creator})
+		if err != nil {
+			return nil, fmt.Errorf("ArchiveProject: failed to sync: %v", err)
+		}
 	}
 
 	project.Archived = true

--- a/pkg/broker/services/intra/project_handler.go
+++ b/pkg/broker/services/intra/project_handler.go
@@ -254,6 +254,7 @@ func (svc *grpcIntraSvc) ArchiveProject(c context.Context, req *pb.ArchiveProjec
 
 	err = common.PostSyncInfo(app, req.GetProjectId(), pb.ChangeEntry_ArchiveProject, nil, targetParties)
 	if err != nil {
+		logrus.Warningf("ArchiveProject: fail to PostSyncInfo %v", err)
 		// still need to archive project locally
 		err = nil
 		return &pb.ArchiveProjectResponse{

--- a/pkg/broker/services/intra/project_handler.go
+++ b/pkg/broker/services/intra/project_handler.go
@@ -254,11 +254,10 @@ func (svc *grpcIntraSvc) ArchiveProject(c context.Context, req *pb.ArchiveProjec
 	if err != nil {
 		// still need to archive project locally
 		err = nil
-		// some members need to execute CheckAndUpdateStatus
 		return &pb.ArchiveProjectResponse{
 			Status: &pb.Status{
 				Code:    int32(pb.Code_OK),
-				Message: "archive project is partially successful",
+				Message: "archive project is partially successful, some members need to execute CheckAndUpdateStatus",
 			},
 		}, nil
 	}

--- a/pkg/broker/services/intra/project_handler.go
+++ b/pkg/broker/services/intra/project_handler.go
@@ -514,6 +514,14 @@ func (svc *grpcIntraSvc) ProcessInvitation(c context.Context, req *pb.ProcessInv
 		return nil, fmt.Errorf("ProcessInvitation: existing project{%+v} conflicts with invitation{%+v}", proj, invitation)
 	}
 
+	if proj.Archived {
+		return &pb.ProcessInvitationResponse{
+			Status: &pb.Status{
+				Code:    int32(pb.Code_NOT_SUPPORTED),
+				Message: fmt.Sprintf("ProcessInvitation: project %v is already archived", proj.ID),
+			}}, nil
+	}
+
 	status := pb.InvitationStatus_DECLINED
 	if req.GetRespond() == pb.InvitationRespond_ACCEPT {
 		logrus.Infof("ProcessInvitation: accept invitation invited by %s to project %s with conf %+v", invitation.Inviter, invitation.ProjectID, invitation.ProjectConf)

--- a/pkg/broker/services/intra/project_handler.go
+++ b/pkg/broker/services/intra/project_handler.go
@@ -286,8 +286,8 @@ func (svc *grpcIntraSvc) InviteMember(c context.Context, req *pb.InviteMemberReq
 		err = txn.Finish(err)
 	}()
 
-	resp, shouldReturn, err := common.CheckProjectArchived[pb.InviteMemberResponse](txn, req.GetProjectId(), "InviteMember")
-	if shouldReturn {
+	resp, err = common.CheckProjectArchived[pb.InviteMemberResponse](txn, req.GetProjectId(), "InviteMember")
+	if resp != nil || err != nil {
 		return resp, err
 	}
 

--- a/pkg/broker/services/intra/query_handler.go
+++ b/pkg/broker/services/intra/query_handler.go
@@ -45,11 +45,16 @@ func validateAndGetProjectConf(app *application.App, projectID string) (*pb.Proj
 	if err != nil {
 		return nil, err
 	}
+
 	var existingProject *storage.Project
 	existingProject, err = app.MetaMgr.GetProject(projectID)
 	if err != nil {
 		return nil, err
 	}
+	if existingProject.Archived {
+		return nil, fmt.Errorf("project %s is archived", projectID)
+	}
+
 	projConf := &pb.ProjectConfig{}
 	err = message.ProtoUnmarshal([]byte(existingProject.ProjectConf), projConf)
 	if err != nil {

--- a/pkg/broker/services/intra/status_handler.go
+++ b/pkg/broker/services/intra/status_handler.go
@@ -204,18 +204,13 @@ func checkConflict(app *application.App, local, remote *storage.ProjectMeta, loc
 	// check project conflict
 	localProj := local.Proj.Proj
 	remoteProj := remote.Proj.Proj
-	remoteProjArchived := remoteProj.Archived
-	remoteProj.Archived = localProj.Archived // ignore comparing Archived
-	defer func() {
-		remoteProj.Archived = remoteProjArchived
-	}()
 
-	eq, err := localProj.Equals(&remoteProj)
+	hasConflict, err := localProj.Conflicts(&remoteProj)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compare project between local project and remote project, %v", err)
 	}
 
-	if !eq {
+	if hasConflict {
 		conflict.Items = append(conflict.Items, &pb.ProjectConflict_ConflictItem{
 			Message: fmt.Sprintf("project info conflict: '%+v' in party %s; '%+v' in party %s", localProj, localParty, remoteProj, remoteParty),
 		})

--- a/pkg/broker/services/intra/svc.go
+++ b/pkg/broker/services/intra/svc.go
@@ -65,6 +65,17 @@ func (svc *IntraSvc) CreateProjectHandler(c *gin.Context) {
 		})
 }
 
+func (svc *IntraSvc) ArchiveProjectHandler(c *gin.Context) {
+	handlerWrapper(c,
+		&pb.ArchiveProjectRequest{},
+		&pb.ArchiveProjectResponse{},
+		func(ctx context.Context, req *pb.ArchiveProjectRequest, logEntry *logutil.BrokerMonitorLogEntry) (*pb.ArchiveProjectResponse, error) {
+			logEntry.RawRequest = req.String()
+			logEntry.ActionName = fmt.Sprintf("%v@%v", "Intra", "ArchiveProject")
+			return svc.ArchiveProject(ctx, req)
+		})
+}
+
 func (svc *IntraSvc) ListProjectsHandler(c *gin.Context) {
 	handlerWrapper(c,
 		&pb.ListProjectsRequest{},

--- a/pkg/broker/services/intra/table_handler.go
+++ b/pkg/broker/services/intra/table_handler.go
@@ -38,16 +38,9 @@ func (svc *grpcIntraSvc) CreateTable(c context.Context, req *pb.CreateTableReque
 		err = txn.Finish(err)
 	}()
 
-	project, err := txn.GetProject(req.GetProjectId())
-	if err != nil {
-		return nil, fmt.Errorf("CreateTable: get project %v err: %v", req.GetProjectId(), err)
-	}
-	if project.Archived {
-		return &pb.CreateTableResponse{
-			Status: &pb.Status{
-				Code:    int32(pb.Code_NOT_SUPPORTED),
-				Message: fmt.Sprintf("CreateTable: project %v is archived", req.GetProjectId()),
-			}}, nil
+	resp, shouldReturn, err := common.CheckProjectArchived[pb.CreateTableResponse](txn, req.GetProjectId(), "CreateTable")
+	if shouldReturn {
+		return resp, err
 	}
 
 	members, err := txn.GetProjectMembers(req.GetProjectId())
@@ -198,16 +191,9 @@ func (svc *grpcIntraSvc) DropTable(c context.Context, req *pb.DropTableRequest) 
 		err = txn.Finish(err)
 	}()
 
-	project, err := txn.GetProject(req.GetProjectId())
-	if err != nil {
-		return nil, fmt.Errorf("DropTable: get project %v err: %v", req.GetProjectId(), err)
-	}
-	if project.Archived {
-		return &pb.DropTableResponse{
-			Status: &pb.Status{
-				Code:    int32(pb.Code_NOT_SUPPORTED),
-				Message: fmt.Sprintf("DropTable: project %v is archived", req.GetProjectId()),
-			}}, nil
+	resp, shouldReturn, err := common.CheckProjectArchived[pb.DropTableResponse](txn, req.GetProjectId(), "DropTable")
+	if shouldReturn {
+		return resp, err
 	}
 
 	tableId := storage.TableIdentifier{

--- a/pkg/broker/services/intra/table_handler.go
+++ b/pkg/broker/services/intra/table_handler.go
@@ -38,8 +38,8 @@ func (svc *grpcIntraSvc) CreateTable(c context.Context, req *pb.CreateTableReque
 		err = txn.Finish(err)
 	}()
 
-	resp, shouldReturn, err := common.CheckProjectArchived[pb.CreateTableResponse](txn, req.GetProjectId(), "CreateTable")
-	if shouldReturn {
+	resp, err = common.CheckProjectArchived[pb.CreateTableResponse](txn, req.GetProjectId(), "CreateTable")
+	if resp != nil || err != nil {
 		return resp, err
 	}
 
@@ -191,8 +191,8 @@ func (svc *grpcIntraSvc) DropTable(c context.Context, req *pb.DropTableRequest) 
 		err = txn.Finish(err)
 	}()
 
-	resp, shouldReturn, err := common.CheckProjectArchived[pb.DropTableResponse](txn, req.GetProjectId(), "DropTable")
-	if shouldReturn {
+	resp, err = common.CheckProjectArchived[pb.DropTableResponse](txn, req.GetProjectId(), "DropTable")
+	if resp != nil || err != nil {
 		return resp, err
 	}
 

--- a/pkg/broker/services/intra/view_handler.go
+++ b/pkg/broker/services/intra/view_handler.go
@@ -125,8 +125,8 @@ func (svc *grpcIntraSvc) CreateView(ctx context.Context, req *pb.CreateViewReque
 		err = txn.Finish(err)
 	}()
 
-	resp, shouldReturn, err := common.CheckProjectArchived[pb.CreateViewResponse](txn, req.GetProjectId(), "CreateView")
-	if shouldReturn {
+	resp, err = common.CheckProjectArchived[pb.CreateViewResponse](txn, req.GetProjectId(), "CreateView")
+	if resp != nil || err != nil {
 		return resp, err
 	}
 
@@ -209,8 +209,8 @@ func (svc *grpcIntraSvc) DropView(ctx context.Context, req *pb.DropViewRequest) 
 		err = txn.Finish(err)
 	}()
 
-	resp, shouldReturn, err := common.CheckProjectArchived[pb.DropViewResponse](txn, req.GetProjectId(), "DropView")
-	if shouldReturn {
+	resp, err = common.CheckProjectArchived[pb.DropViewResponse](txn, req.GetProjectId(), "DropView")
+	if resp != nil || err != nil {
 		return resp, err
 	}
 

--- a/pkg/broker/services/intra/view_handler.go
+++ b/pkg/broker/services/intra/view_handler.go
@@ -125,6 +125,11 @@ func (svc *grpcIntraSvc) CreateView(ctx context.Context, req *pb.CreateViewReque
 		err = txn.Finish(err)
 	}()
 
+	resp, shouldReturn, err := common.CheckProjectArchived[pb.CreateViewResponse](txn, req.GetProjectId(), "CreateView")
+	if shouldReturn {
+		return resp, err
+	}
+
 	tables, err := txn.GetAllTables(req.GetProjectId())
 	if err != nil {
 		return nil, fmt.Errorf("CreateView: %s", err.Error())
@@ -193,20 +198,35 @@ func (svc *grpcIntraSvc) CreateView(ctx context.Context, req *pb.CreateViewReque
 		}}, nil
 }
 
-func (svc *grpcIntraSvc) DropView(ctx context.Context, req *pb.DropViewRequest) (*pb.DropViewResponse, error) {
+func (svc *grpcIntraSvc) DropView(ctx context.Context, req *pb.DropViewRequest) (resp *pb.DropViewResponse, err error) {
+	if req == nil || req.GetProjectId() == "" || req.GetViewName() == "" {
+		return nil, status.New(pb.Code_BAD_REQUEST, "DropView: illegal request")
+	}
+
+	app := svc.app
+	txn := app.MetaMgr.CreateMetaTransaction()
+	defer func() {
+		err = txn.Finish(err)
+	}()
+
+	resp, shouldReturn, err := common.CheckProjectArchived[pb.DropViewResponse](txn, req.GetProjectId(), "DropView")
+	if shouldReturn {
+		return resp, err
+	}
+
 	dropTableReq := &pb.DropTableRequest{
 		ProjectId: req.GetProjectId(),
 		TableName: req.GetViewName(),
 	}
-	resp, err := svc.DropTable(ctx, dropTableReq)
+	dropTableResp, err := svc.DropTable(ctx, dropTableReq)
 	if err != nil {
 		return nil, fmt.Errorf("DropView: drop table err: %v", err)
 	}
 
-	if resp.Status == nil {
+	if dropTableResp.Status == nil {
 		return nil, fmt.Errorf("DropView: status is nil")
 	}
-	if resp.GetStatus().GetCode() == 0 {
+	if dropTableResp.GetStatus().GetCode() == 0 {
 		return &pb.DropViewResponse{
 			Status: &pb.Status{
 				Code:    int32(0),
@@ -216,8 +236,8 @@ func (svc *grpcIntraSvc) DropView(ctx context.Context, req *pb.DropViewRequest) 
 	} else {
 		return &pb.DropViewResponse{
 			Status: &pb.Status{
-				Code:    resp.GetStatus().GetCode(),
-				Message: resp.GetStatus().GetMessage(),
+				Code:    dropTableResp.GetStatus().GetCode(),
+				Message: dropTableResp.GetStatus().GetMessage(),
 			},
 		}, nil
 	}

--- a/pkg/broker/storage/model.go
+++ b/pkg/broker/storage/model.go
@@ -38,34 +38,35 @@ type Project struct {
 	UpdatedAt   time.Time
 }
 
-func (p *Project) Equals(other *Project) (bool, error) {
-	// compare each field except for time fields
+// Util func for CheckAndUpdateStatus
+// Returns true if the two projects conflict
+func (p *Project) Conflicts(other *Project) (bool, error) {
+	// compare each field except for time/archived fields
 	if p.ID != other.ID ||
 		p.Name != other.Name ||
 		p.Description != other.Description ||
-		p.Creator != other.Creator ||
-		p.Archived != other.Archived {
-		return false, nil
+		p.Creator != other.Creator {
+		return true, nil
 	}
 
 	var projConf pb.ProjectConfig
 	if len(p.ProjectConf) == 0 && len(other.ProjectConf) == 0 {
-		return true, nil
+		return false, nil
 	}
 	err := message.ProtoUnmarshal([]byte(p.ProjectConf), &projConf)
 
 	if err != nil {
-		return false, err
+		return true, err
 	}
 
 	var otherProjConf pb.ProjectConfig
 	err = message.ProtoUnmarshal([]byte(other.ProjectConf), &otherProjConf)
 
 	if err != nil {
-		return false, err
+		return true, err
 	}
 
-	return proto.Equal(&projConf, &otherProjConf), nil
+	return !proto.Equal(&projConf, &otherProjConf), nil
 }
 
 type Member struct {

--- a/pkg/util/brokerutil/broker_stub_util.go
+++ b/pkg/util/brokerutil/broker_stub_util.go
@@ -112,6 +112,22 @@ func (c *Command) CreateProject(projectID, projectConf string) (string, error) {
 	}
 }
 
+func (c *Command) ArchiveProject(projectID string) error {
+	if projectID == "" {
+		return fmt.Errorf("ArchiveProject: projectId must not be empty")
+	}
+
+	req := &pb.ArchiveProjectRequest{ProjectId: projectID}
+	response := &pb.ArchiveProjectResponse{}
+	err := c.intraStub.ArchiveProject(c.host, req, response)
+	if err != nil {
+		return fmt.Errorf("ArchiveProject: failed to call archiving project service: %v", err)
+	}
+
+	wrapper := NewResponseWrapper(response)
+	return handleResponse(wrapper, "ArchiveProject")
+}
+
 func (c *Command) CreateView(projectId, viewName, body string) error {
 	if projectId == "" {
 		return fmt.Errorf("CreateView: projectId must not be empty")

--- a/pkg/util/brokerutil/broker_stub_util.go
+++ b/pkg/util/brokerutil/broker_stub_util.go
@@ -112,20 +112,26 @@ func (c *Command) CreateProject(projectID, projectConf string) (string, error) {
 	}
 }
 
-func (c *Command) ArchiveProject(projectID string) error {
+func (c *Command) ArchiveProject(projectID string) (string, error) {
 	if projectID == "" {
-		return fmt.Errorf("ArchiveProject: projectId must not be empty")
+		return "", fmt.Errorf("ArchiveProject: projectId must not be empty")
 	}
 
 	req := &pb.ArchiveProjectRequest{ProjectId: projectID}
 	response := &pb.ArchiveProjectResponse{}
 	err := c.intraStub.ArchiveProject(c.host, req, response)
 	if err != nil {
-		return fmt.Errorf("ArchiveProject: failed to call archiving project service: %v", err)
+		return "", fmt.Errorf("ArchiveProject: failed to call archiving project service: %v", err)
 	}
 
-	wrapper := NewResponseWrapper(response)
-	return handleResponse(wrapper, "ArchiveProject")
+	if response.Status == nil {
+		return "", fmt.Errorf("ArchiveProject: invalid response: status is nil")
+	}
+	if response.GetStatus().GetCode() == 0 {
+		return response.GetStatus().Message, nil
+	} else {
+		return "", fmt.Errorf("ArchiveProject: status: %v", response.GetStatus())
+	}
 }
 
 func (c *Command) CreateView(projectId, viewName, body string) error {


### PR DESCRIPTION
- Any project member can initiate an archive project request and broadcast it to the other members of the project.
- As long as the project creator receives the request and responds with success, the member who initiated the archive project can consider the archive operation successful.
- For members who did not receive the broadcast message, they need to execute CheckAndUpdateStatus to synchronize their status.
- Once a project is archived, it cannot be modified or used to initiate new queries, but historical data can still be accessed.