### PR TITLE
Refactor: Support timezone for timestamp(Implicit Conversion)

### DIFF
--- a/pkg/interpreter/graph/graph_optimizer.go
+++ b/pkg/interpreter/graph/graph_optimizer.go
@@ -166,14 +166,6 @@ func isValidCast(originType, castType proto.PrimitiveDataType) bool {
 			proto.PrimitiveDataType_INT32:  true,
 			proto.PrimitiveDataType_STRING: true,
 		},
-		proto.PrimitiveDataType_DATETIME: {
-			proto.PrimitiveDataType_STRING: true,
-			proto.PrimitiveDataType_INT64:  true,
-		},
-		proto.PrimitiveDataType_TIMESTAMP: {
-			proto.PrimitiveDataType_STRING: true,
-			proto.PrimitiveDataType_INT64:  true,
-		},
 	}
 
 	if validCastMap, ok := validCasts[originType]; ok {
@@ -222,7 +214,7 @@ func castValue(scalarAttr *Attribute, originType, castType proto.PrimitiveDataTy
 				scalarAttr.SetInt64(unixSec)
 				return nil
 			}
-			return fmt.Errorf("datetime constant format should be 'YYYY-MM-DD hh:mm:ss'")
+			return fmt.Errorf("datetime constant format should be 'YYYY-MM-DD hh:mm:ss', but got %s", strVal)
 		} else if castType == proto.PrimitiveDataType_TIMESTAMP {
 			unixSec, err := stringutil.StringToUnixSecWithTimezone(strVal)
 			if err != nil {

--- a/pkg/util/stringutil/string_util.go
+++ b/pkg/util/stringutil/string_util.go
@@ -371,8 +371,6 @@ func StringToUnixSecWithTimezone(s string) (int64, error) {
 		"2006-01-02 15:04:05Z07:00",
 		// e.g., "2024-10-25 10:00:00+0800"
 		"2006-01-02 15:04:05Z0700",
-		// e.g., "2024-10-25 10:00:00 PST"
-		"2006-01-02 15:04:05 MST",
 	}
 
 	var t time.Time

--- a/pkg/util/stringutil/string_util.go
+++ b/pkg/util/stringutil/string_util.go
@@ -358,5 +358,32 @@ func StringToUnixSec(s string) (int64, error) {
 		}
 	}
 
-	return 0, fmt.Errorf("StringToUnixMilli: unsupported date/time format: %s", s)
+	return 0, fmt.Errorf("unsupported datetime format: %s", s)
+}
+
+func StringToUnixSecWithTimezone(s string) (int64, error) {
+	supportedLayouts := []string{
+		// e.g., "2024-10-25T10:00:00+08:00" or "2024-10-25T02:00:00Z"
+		time.RFC3339,
+		// e.g., "2024-10-25T10:00:00+0800"
+		"2006-01-02T15:04:05Z0700",
+		// e.g., "2024-10-25 10:00:00+08:00"
+		"2006-01-02 15:04:05Z07:00",
+		// e.g., "2024-10-25 10:00:00+0800"
+		"2006-01-02 15:04:05Z0700",
+		// e.g., "2024-10-25 10:00:00 PST"
+		"2006-01-02 15:04:05 MST",
+	}
+
+	var t time.Time
+	var err error
+
+	for _, layout := range supportedLayouts {
+		t, err = time.Parse(layout, s)
+		if err == nil {
+			return t.Unix(), nil
+		}
+	}
+
+	return 0, fmt.Errorf("unsupported timestamp format or missing timezone: %q", s)
 }

--- a/pkg/util/stringutil/string_util_test.go
+++ b/pkg/util/stringutil/string_util_test.go
@@ -344,6 +344,18 @@ func TestStringToUnixSecWithTimezone(t *testing.T) {
 			expectErr:  true,
 			comment:    "Failure: empty string",
 		},
+		{
+			in:         "2024-11-20 10:00:00 MST",
+			expectUnix: 0,
+			expectErr:  true,
+			comment:    "Failure: mbiguous formats",
+		},
+		{
+			in:         "2024-12-10 15:00:00 PST",
+			expectUnix: 0,
+			expectErr:  true,
+			comment:    "Failure: mbiguous formats",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
support queries such as
`select * from ta.ts > '2024-05-01T18:00:00+08:00'`
`select * from ta.ts > '2024-05-01T10:00:00Z'`