### PR TITLE
Fix: Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Secure Collaborative Query Language (SCQL) is a system that translates SQL state
 ## Docker Image Release
 
 - Official release docker image: [secretflow/scql](https://hub.docker.com/r/secretflow/scql/tags)
-- We also have mirrors at Alibaba Cloud: secretflow-registry.cn-hangzhou.cr.aliyuncs.com/secretflow/scql:[tag]
+- We also have images at Alibaba Cloud: secretflow-registry.cn-hangzhou.cr.aliyuncs.com/secretflow/scql:[tag]
 
 ## Contribution Guidelines
 


### PR DESCRIPTION
For containers, we should use term "image" instead of "mirror".