### PR TITLE
chore: add more log info for jobWatcher

### DIFF
--- a/pkg/broker/application/worker.go
+++ b/pkg/broker/application/worker.go
@@ -146,7 +146,7 @@ func (w *cronJobWorker) start() error {
 				}
 				ok, err := storage.NewDistributeLockGuard(w.manager).PreemptDistributedLock(storage.DistributedLockID, w.id, w.interval)
 				if err != nil {
-					logrus.Infof("current instance fails to preempt lock and works as slave: %v", err)
+					logrus.Infof("current instance failed to preempt lock, continues as follower: %v", err)
 					return
 				}
 				if ok {
@@ -156,7 +156,7 @@ func (w *cronJobWorker) start() error {
 						return
 					}
 					w.setRole(Leader)
-					logrus.Infof("current instance is successfully elected and works as leader with name %s", w.id)
+					logrus.Infof("current instance successfully elected, now acting as leader %s", w.id)
 				}
 				return
 			}
@@ -169,8 +169,10 @@ func (w *cronJobWorker) start() error {
 					return
 				}
 				w.setRole(Worker)
+				logrus.Infof("current instance failed to renew leader lock, now acting as follower: %v", err)
+			} else {
+				logrus.Infof("leader lock renewed, current instance continues as leader %s", w.id)
 			}
-			logrus.Infof("current instance re-elects and works as leader with name %s", w.id)
 		}),
 		gocron.WithName("election"),
 	)

--- a/pkg/broker/application/worker.go
+++ b/pkg/broker/application/worker.go
@@ -146,7 +146,7 @@ func (w *cronJobWorker) start() error {
 				}
 				ok, err := storage.NewDistributeLockGuard(w.manager).PreemptDistributedLock(storage.DistributedLockID, w.id, w.interval)
 				if err != nil {
-					logrus.Warnf("fail to preempt lock: %v", err)
+					logrus.Infof("current instance fails to preempt lock and works as slave: %v", err)
 					return
 				}
 				if ok {
@@ -156,7 +156,7 @@ func (w *cronJobWorker) start() error {
 						return
 					}
 					w.setRole(Leader)
-					logrus.Infof("current instance work as leader with name %s", w.id)
+					logrus.Infof("current instance is successfully elected and works as leader with name %s", w.id)
 				}
 				return
 			}
@@ -170,6 +170,7 @@ func (w *cronJobWorker) start() error {
 				}
 				w.setRole(Worker)
 			}
+			logrus.Infof("current instance re-elects and works as leader with name %s", w.id)
 		}),
 		gocron.WithName("election"),
 	)


### PR DESCRIPTION
- 测试过程中经常会遇到多个 broker 连到同一个 db，然后 job 被其他未销毁 broker 停止的情况，且从报错信息上难以看出原因
- 增加 jobwatcher 相关日志便于排查
