### PR TITLE
CI: trigger regtest monthly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,24 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the latest 2.1 version of CircleCI pipeline process engine.
-# See: https://circleci.com/docs/2.0/configuration-reference
-
 version: 2.1
 
 setup: true
 
 orbs:
   path-filtering: circleci/path-filtering@2.0.1
-  continuation: circleci/continuation@1.0.0
+  continuation: circleci/continuation@2.0.1
 
 parameters:
   enable_regtest:
     type: boolean
     default: false
 
-# Invoke jobs via workflows
-# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:
   run_ut:
     when:
@@ -43,7 +38,5 @@ workflows:
   run_regtest:
     when: << pipeline.parameters.enable_regtest >>
     jobs:
-      - path-filtering/filter:
-          base-revision: main
-          config-path: .circleci/regtest-config.yml
-          mapping: .circleci/path-filtering/regtest.conf
+      - continuation/continue:
+          configuration_path: .circleci/regtest-config.yml

--- a/.circleci/path-filtering/regtest.conf
+++ b/.circleci/path-filtering/regtest.conf
@@ -1,7 +1,0 @@
-api/.* run_regtest true
-bazel/.* run_regtest true
-cmd/.* run_regtest true
-engine/.* run_regtest true
-pkg/.* run_regtest true
-.bazelrc run_regtest true
-.circleci/regtest-config.yml run_regtest true

--- a/.circleci/regtest-config.yml
+++ b/.circleci/regtest-config.yml
@@ -17,11 +17,6 @@
 
 version: 2.1
 
-parameters:
-  run_regtest:
-    type: boolean
-    default: false
-
 jobs:
   linux_regtest:
     machine:
@@ -96,7 +91,6 @@ jobs:
 
 workflows:
   regtest:
-    when: << pipeline.parameters.run_regtest >>
     jobs:
       - linux_regtest:
           matrix:

--- a/.github/workflows/trigger-ci-regtest.yml
+++ b/.github/workflows/trigger-ci-regtest.yml
@@ -1,0 +1,21 @@
+name: "Monthly Trigger for CircleCI Regtest"
+
+on:
+  schedule:
+    # cron: minute hour day month day-of-week
+    # Trigger at 08:00 UTC on the 1st day of every month
+    - cron: '0 8 1 * *'
+
+jobs:
+  trigger-circleci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger CircleCI Monthly Pipeline
+        run: |
+          echo "Scheduled monthly trigger fired. Triggering CircleCI pipeline for main branch..."
+
+          curl -X POST \
+            --url "https://circleci.com/api/v2/project/github/secretflow/scql/pipeline/run" \
+            --header "Content-Type: application/json" \
+            --header "Circle-Token: ${{ secrets.CCI_TOKEN }}" \
+            --data '{"definition_id":"c6f435ca-697f-488c-83da-156862bb7392","config":{"branch":"main"},"checkout":{"branch":"main"},"parameters":{"enable_regtest":true}}'


### PR DESCRIPTION
- 原先的 regtest 因为 parameters 错误一直并为生效
- OAuth 移除后，scheduled trigger 没有权限，无法继续执行 regtest
- 改为使用 github action 每月触发 pipeline