### PR TITLE
Fix: unexpected arg regtest

### DIFF
--- a/.circleci/regtest-config.yml
+++ b/.circleci/regtest-config.yml
@@ -17,6 +17,11 @@
 
 version: 2.1
 
+parameters:
+  enable_regtest:
+    type: boolean
+    default: false
+
 jobs:
   linux_regtest:
     machine:

--- a/.github/workflows/trigger-ci-regtest.yml
+++ b/.github/workflows/trigger-ci-regtest.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # cron: minute hour day month day-of-week
     # Trigger at 08:00 UTC on the 1st day of every month
-    - cron: '0 8 1 * *'
+    - cron: '5 9 1 * *'
 
 jobs:
   trigger-circleci:


### PR DESCRIPTION
- 触发回归测试的时候遇到
<img width="2788" height="420" alt="image" src="https://github.com/user-attachments/assets/b9e904b3-c43d-434a-8425-93bb48553fdf" />

解决
> pipeline parameters declared in the setup configuration must also be declared in the continuation configuration, and can be used at continuation time