### PR TITLE
CI: update regtest machine

### DIFF
--- a/.circleci/regtest-config.yml
+++ b/.circleci/regtest-config.yml
@@ -25,7 +25,7 @@ parameters:
 jobs:
   linux_regtest:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     parameters:
       resource_class:
         type: string

--- a/.circleci/regtest-config.yml
+++ b/.circleci/regtest-config.yml
@@ -25,7 +25,7 @@ parameters:
 jobs:
   linux_regtest:
     machine:
-      image: ubuntu-2004:2022.07.1
+      image: ubuntu-2004:current
     parameters:
       resource_class:
         type: string

--- a/.github/workflows/trigger-ci-regtest.yml
+++ b/.github/workflows/trigger-ci-regtest.yml
@@ -3,8 +3,8 @@ name: "Monthly Trigger for CircleCI Regtest"
 on:
   schedule:
     # cron: minute hour day month day-of-week
-    # Trigger at 08:00 UTC on the 1st day of every month
-    - cron: '5 9 1 * *'
+    # Trigger at 00:00 UTC on the 1st day of every month
+    - cron: '0 0 1 * *'
 
 jobs:
   trigger-circleci:


### PR DESCRIPTION
- 触发 regtest 报错
   - Job was rejected because resource class 2xlarge, image ubuntu-2004:2022.07.1 is not a valid resource class
   - Job was rejected because resource class arm.xlarge, image ubuntu-2004:2022.07.1 is not a valid resource class
- 解决
   - https://circleci.com/docs/using-arm/#ubuntu-20-04-focal 老机器已经不支持了