### PR TITLE
CI: ut/cov optimization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ workflows:
     jobs:
       - path-filtering/filter:
           base-revision: main
-          config-path: .circleci/unittest-config.yml
+          config-path: .circleci/lite-unittest-config.yml
           mapping: .circleci/path-filtering/unittest.conf
 
   run_regtest:

--- a/.circleci/coverage-config.yml
+++ b/.circleci/coverage-config.yml
@@ -26,27 +26,27 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v4-go-modules-{{ checksum "go.sum" }}
-            - v4-go-modules-
+            - v1-linux-go-modules-{{ checksum "go.sum" }}
+            - v1-linux-go-modules-
       - run:
-          name: "Download Go Modules"
+          name: "Tidy and Download Go Modules"
           command: |
             go mod tidy
             go mod download
       - save_cache:
-          key: v4-go-modules-{{ checksum "go.sum" }}
+          key: v1-linux-go-modules-{{ checksum "go.sum" }}
           paths:
             - /usr/local/pkg/mod
 
       - restore_cache:
           keys:
-            - v4-go-bin-gcov2lcov
+            - v1-linux-go-bin-gcov2lcov
       - run:
           name: Install gcov2lcov if not cached
           command: |
             which gcov2lcov || go install github.com/jandelgado/gcov2lcov@latest
       - save_cache:
-          key: v4-go-bin-gcov2lcov
+          key: v1-linux-go-bin-gcov2lcov
           paths:
             - /usr/local/bin
 

--- a/.circleci/coverage-config.yml
+++ b/.circleci/coverage-config.yml
@@ -71,7 +71,7 @@ commands:
             gcov2lcov -infile=coverage.out -outfile=coverage.lcov
 
   run_cpp_test:
-    description: "Run cpp tests and collect artifacts"
+    description: "Run cpp cov tests and collect artifacts"
     parameters:
       extra_bazel_args:
         type: string
@@ -100,12 +100,12 @@ commands:
               echo "Processing coverage..."
               lcov --remove bazel-out/_coverage/_coverage_report.dat '*.pb.h' '*.pb.cc' -o bazel-out/_coverage/_coverage_report_filtered.dat
             else
-              echo "Bazel coverage failed, skipping lcov processing."
+              echo "Bazel coverage failed, skipping lcov processing. Archiving binaries and logs..."
+              find bazel-bin/ << parameters.find_executable_flag >> -type f -name "*_test" -print0 | xargs -0 tar -cvzf test_binary.tar.gz
+              find bazel-testlogs/ -type f -name "test.log" -print0 | xargs -0 tar -cvzf test_logs.tar.gz
             fi
 
             sh ../devtools/rename-junit-xml.sh
-            find bazel-bin/ << parameters.find_executable_flag >> -type f -name "*_test" -print0 | xargs -0 tar -cvzf test_binary.tar.gz
-            find bazel-testlogs/ -type f -name "test.log" -print0 | xargs -0 tar -cvzf test_logs.tar.gz
             exit ${test_status}
 
 jobs:
@@ -142,8 +142,10 @@ jobs:
       - store_test_results:
           path: test-results
       - store_artifacts:
+          when: on_fail
           path: test_binary.tar.gz
       - store_artifacts:
+          when: on_fail
           path: test_logs.tar.gz
 
 workflows:

--- a/.circleci/coverage-config.yml
+++ b/.circleci/coverage-config.yml
@@ -21,6 +21,33 @@ orbs:
   coveralls: coveralls/coveralls@2.2.5
 
 commands:
+  setup_go_test:
+    description: "Restores Go module cache, downloads dependencies, and saves the cache."
+    steps:
+      - restore_cache:
+          keys:
+            - v1-go-modules-{{ checksum "go.sum" }}
+            - v1-go-modules-
+      - run:
+          name: "Download Go Modules"
+          command: go mod download
+      - save_cache:
+          key: v1-go-modules-{{ checksum "go.sum" }}
+          paths:
+            - /go/pkg/mod
+
+      - restore_cache:
+          keys:
+            - v1-go-bin-gcov2lcov
+      - run:
+          name: Install gcov2lcov if not cached
+          command: |
+            which gcov2lcov || go install github.com/jandelgado/gcov2lcov@latest
+      - save_cache:
+          key: v1-go-bin-gcov2lcov
+          paths:
+            - /go/bin
+
   setup_cpp_test:
     steps:
       - run:
@@ -88,9 +115,7 @@ jobs:
     resource_class: "2xlarge"
     steps:
       - checkout
-      - run:
-          name: Install gcov2lcov
-          command: go install github.com/jandelgado/gcov2lcov@latest
+      - setup_go_test
       - run_go_test
       - coveralls/upload:
           coverage_file: coverage.lcov

--- a/.circleci/coverage-config.yml
+++ b/.circleci/coverage-config.yml
@@ -26,29 +26,29 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v2-go-modules-{{ checksum "go.sum" }}
-            - v2-go-modules-
+            - v4-go-modules-{{ checksum "go.sum" }}
+            - v4-go-modules-
       - run:
           name: "Download Go Modules"
           command: |
             go mod tidy
             go mod download
       - save_cache:
-          key: v2-go-modules-{{ checksum "go.sum" }}
+          key: v4-go-modules-{{ checksum "go.sum" }}
           paths:
-            - /go/pkg/mod
+            - /usr/local/pkg/mod
 
       - restore_cache:
           keys:
-            - v2-go-bin-gcov2lcov
+            - v4-go-bin-gcov2lcov
       - run:
           name: Install gcov2lcov if not cached
           command: |
             which gcov2lcov || go install github.com/jandelgado/gcov2lcov@latest
       - save_cache:
-          key: v2-go-bin-gcov2lcov
+          key: v4-go-bin-gcov2lcov
           paths:
-            - /go/bin
+            - /usr/local/bin
 
   setup_cpp_test:
     steps:

--- a/.circleci/coverage-config.yml
+++ b/.circleci/coverage-config.yml
@@ -112,7 +112,7 @@ jobs:
   linux_go_cov:
     docker:
       - image: secretflow/scql-ci:latest
-    resource_class: "2xlarge"
+    resource_class: "large"
     steps:
       - checkout
       - setup_go_test

--- a/.circleci/coverage-config.yml
+++ b/.circleci/coverage-config.yml
@@ -27,7 +27,6 @@ commands:
       - restore_cache:
           keys:
             - v1-linux-go-modules-{{ checksum "go.sum" }}
-            - v1-linux-go-modules-
       - run:
           name: "Tidy and Download Go Modules"
           command: |
@@ -37,18 +36,6 @@ commands:
           key: v1-linux-go-modules-{{ checksum "go.sum" }}
           paths:
             - /usr/local/pkg/mod
-
-      - restore_cache:
-          keys:
-            - v1-linux-go-bin-gcov2lcov
-      - run:
-          name: Install gcov2lcov if not cached
-          command: |
-            which gcov2lcov || go install github.com/jandelgado/gcov2lcov@latest
-      - save_cache:
-          key: v1-linux-go-bin-gcov2lcov
-          paths:
-            - /usr/local/bin
 
   setup_cpp_test:
     steps:
@@ -62,6 +49,10 @@ commands:
   run_go_test:
     description: "Run go cov tests"
     steps:
+      - run:
+          name: Install gcov2lcov
+          command: |
+            which gcov2lcov || go install github.com/jandelgado/gcov2lcov@latest
       - run:
           name: "Go Cov Test"
           command: |

--- a/.circleci/coverage-config.yml
+++ b/.circleci/coverage-config.yml
@@ -30,7 +30,9 @@ commands:
             - v1-go-modules-
       - run:
           name: "Download Go Modules"
-          command: go mod download
+          command: |
+            go mod tidy
+            go mod download
       - save_cache:
           key: v1-go-modules-{{ checksum "go.sum" }}
           paths:
@@ -64,9 +66,8 @@ commands:
           name: "Go Cov Test"
           command: |
             set +e
-            go mod tidy
             echo "Running tests with coverage..."
-            go test -timeout=30m -v -cover -race -coverprofile=coverage.tmp ./pkg/... ./contrib/...
+            go test -mod=readonly -timeout=30m -v -cover -race -coverprofile=coverage.tmp ./pkg/... ./contrib/...
             cat coverage.tmp | grep -v '\.pb\.go:\|_mock\.go:' > coverage.out
             gcov2lcov -infile=coverage.out -outfile=coverage.lcov
 

--- a/.circleci/coverage-config.yml
+++ b/.circleci/coverage-config.yml
@@ -26,27 +26,27 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v1-go-modules-{{ checksum "go.sum" }}
-            - v1-go-modules-
+            - v2-go-modules-{{ checksum "go.sum" }}
+            - v2-go-modules-
       - run:
           name: "Download Go Modules"
           command: |
             go mod tidy
             go mod download
       - save_cache:
-          key: v1-go-modules-{{ checksum "go.sum" }}
+          key: v2-go-modules-{{ checksum "go.sum" }}
           paths:
             - /go/pkg/mod
 
       - restore_cache:
           keys:
-            - v1-go-bin-gcov2lcov
+            - v2-go-bin-gcov2lcov
       - run:
           name: Install gcov2lcov if not cached
           command: |
             which gcov2lcov || go install github.com/jandelgado/gcov2lcov@latest
       - save_cache:
-          key: v1-go-bin-gcov2lcov
+          key: v2-go-bin-gcov2lcov
           paths:
             - /go/bin
 

--- a/.circleci/coverage-config.yml
+++ b/.circleci/coverage-config.yml
@@ -22,20 +22,11 @@ orbs:
 
 commands:
   setup_go_test:
-    description: "Restores Go module cache, downloads dependencies, and saves the cache."
     steps:
-      - restore_cache:
-          keys:
-            - v1-linux-go-modules-{{ checksum "go.sum" }}
       - run:
-          name: "Tidy and Download Go Modules"
+          name: Install gcov2lcov
           command: |
-            go mod tidy
-            go mod download
-      - save_cache:
-          key: v1-linux-go-modules-{{ checksum "go.sum" }}
-          paths:
-            - /usr/local/pkg/mod
+            which gcov2lcov || go install github.com/jandelgado/gcov2lcov@latest
 
   setup_cpp_test:
     steps:
@@ -50,13 +41,10 @@ commands:
     description: "Run go cov tests"
     steps:
       - run:
-          name: Install gcov2lcov
-          command: |
-            which gcov2lcov || go install github.com/jandelgado/gcov2lcov@latest
-      - run:
           name: "Go Cov Test"
           command: |
             set +e
+            go mod tidy
             echo "Running tests with coverage..."
             go test -mod=readonly -timeout=30m -v -cover -race -coverprofile=coverage.tmp ./pkg/... ./contrib/...
             cat coverage.tmp | grep -v '\.pb\.go:\|_mock\.go:' > coverage.out

--- a/.circleci/full-unittest-config.yml
+++ b/.circleci/full-unittest-config.yml
@@ -18,29 +18,6 @@
 version: 2.1
 
 commands:
-  setup_go_test:
-    description: "Set up Go environment for a specific OS."
-    parameters:
-      os_identifier:
-        type: string
-        description: "An identifier for the OS, used in the cache key (e.g., 'linux', 'macos')."
-      cache_path:
-        type: string
-        description: "The absolute path to the Go module cache directory."
-    steps:
-      - restore_cache:
-          keys:
-            - v1-<< parameters.os_identifier >>-go-modules-{{ checksum "go.sum" }}
-      - run:
-          name: "Tidy and Download Go Modules"
-          command: |
-            go mod tidy
-            go mod download
-      - save_cache:
-          key: v1-<< parameters.os_identifier >>-go-modules-{{ checksum "go.sum" }}
-          paths:
-            - << parameters.cache_path >>
-
   setup_cpp_test:
     steps:
       - run:
@@ -57,6 +34,7 @@ commands:
           name: "Go Test"
           command: |
             set +e
+            go mod tidy
             echo "Running unit tests..."
             go test -mod=readonly -timeout=30m -v -short ./pkg/... ./contrib/...
 
@@ -105,9 +83,6 @@ jobs:
     resource_class: << parameters.resource_class >>
     steps:
       - checkout
-      - setup_go_test:
-          os_identifier: linux
-          cache_path: /usr/local/pkg/mod
       - run_go_test
 
   linux_cpp_ut:
@@ -142,9 +117,6 @@ jobs:
           name: "Install homebrew dependencies"
           command: |
             brew install wget go
-      - setup_go_test:
-          os_identifier: macos
-          cache_path: /Users/distiller/go/pkg/mod
       - run_go_test
 
   macOS_cpp_ut:

--- a/.circleci/full-unittest-config.yml
+++ b/.circleci/full-unittest-config.yml
@@ -17,14 +17,6 @@
 
 version: 2.1
 
-parameters:
-  run_go_ut:
-    type: boolean
-    default: false
-  run_cpp_ut:
-    type: boolean
-    default: false
-
 commands:
   setup_go_test:
     description: "Set up Go environment for a specific OS."
@@ -182,7 +174,6 @@ jobs:
 
 workflows:
   run_go_ut:
-    when: << pipeline.parameters.run_go_ut >>
     jobs:
       - linux_go_ut:
           matrix:
@@ -190,7 +181,6 @@ workflows:
               resource_class: ["large", "arm.large"]
       - macOS_go_ut
   run_cpp_ut:
-    when: << pipeline.parameters.run_cpp_ut >>
     jobs:
       - linux_cpp_ut:
           matrix:

--- a/.circleci/full-unittest-config.yml
+++ b/.circleci/full-unittest-config.yml
@@ -31,7 +31,6 @@ commands:
       - restore_cache:
           keys:
             - v1-<< parameters.os_identifier >>-go-modules-{{ checksum "go.sum" }}
-            - v1-<< parameters.os_identifier >>-go-modules-
       - run:
           name: "Tidy and Download Go Modules"
           command: |

--- a/.circleci/lite-unittest-config.yml
+++ b/.circleci/lite-unittest-config.yml
@@ -1,0 +1,128 @@
+# Copyright 2025 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/2.0/configuration-reference
+
+version: 2.1
+
+parameters:
+  run_go_ut:
+    type: boolean
+    default: false
+  run_cpp_ut:
+    type: boolean
+    default: false
+
+commands:
+  setup_go_test:
+    steps:
+      - restore_cache:
+          keys:
+            - v1-linux-go-modules-{{ checksum "go.sum" }}
+            - v1-linux-go-modules-
+      - run:
+          name: "Tidy and Download Go Modules"
+          command: |
+            go mod tidy
+            go mod download
+      - save_cache:
+          key: v1-linux-go-modules-{{ checksum "go.sum" }}
+          paths:
+            - /usr/local/pkg/mod
+
+  setup_cpp_test:
+    steps:
+      - run:
+          name: "Checkout devtools"
+          command: git clone --depth=1 https://github.com/secretflow/devtools.git ../devtools
+      - run:
+          name: Setup BuildBuddy Cache
+          command: ../devtools/bazel_cache_setup.py
+
+  run_go_test:
+    description: "Run go tests"
+    steps:
+      - run:
+          name: "Go Test"
+          command: |
+            set +e
+            echo "Running unit tests..."
+            go test -mod=readonly -timeout=30m -v -short ./pkg/... ./contrib/...
+
+  run_cpp_test:
+    description: "Run cpp tests and collect artifacts on fail"
+    steps:
+      - run:
+          name: "Cpp Test"
+          command: |
+            set +e
+            declare -i test_status
+
+            echo "Running unit tests..."
+            bazelisk --host_jvm_args=-Xmx8g test //engine/... \
+                -c opt \
+                --jobs=auto \
+                --ui_event_filters=-info,-debug,-warning \
+                --test_output=errors | tee test_result.log
+
+            # Capture the exit status of the Bazel command
+            test_status=${PIPESTATUS[0]}
+
+            sh ../devtools/rename-junit-xml.sh
+            if [ ${test_status} -ne 0 ]; then
+              echo "Tests failed. Archiving binaries and logs..."
+              find bazel-bin/ -executable -type f -name "*_test" -print0 | xargs -0 tar -cvzf test_binary.tar.gz
+              find bazel-testlogs/ -type f -name "test.log" -print0 | xargs -0 tar -cvzf test_logs.tar.gz
+            fi
+
+            exit ${test_status}
+
+jobs:
+  linux_go_ut:
+    docker:
+      - image: secretflow/scql-ci:latest
+    resource_class: "large"
+    steps:
+      - checkout
+      - setup_go_test
+      - run_go_test
+
+  linux_cpp_ut:
+    docker:
+      - image: secretflow/scql-ci:latest
+    resource_class: "2xlarge"
+    steps:
+      - checkout
+      - setup_cpp_test
+      - run_cpp_test
+      - store_test_results:
+          path: test-results
+      - store_artifacts:
+          when: on_fail
+          path: test_binary.tar.gz
+      - store_artifacts:
+          when: on_fail
+          path: test_logs.tar.gz
+
+workflows:
+  run_go_ut:
+    when: << pipeline.parameters.run_go_ut >>
+    jobs:
+      - linux_go_ut
+
+  run_cpp_ut:
+    when: << pipeline.parameters.run_cpp_ut >>
+    jobs:
+      - linux_cpp_ut

--- a/.circleci/lite-unittest-config.yml
+++ b/.circleci/lite-unittest-config.yml
@@ -31,7 +31,6 @@ commands:
       - restore_cache:
           keys:
             - v1-linux-go-modules-{{ checksum "go.sum" }}
-            - v1-linux-go-modules-
       - run:
           name: "Tidy and Download Go Modules"
           command: |

--- a/.circleci/lite-unittest-config.yml
+++ b/.circleci/lite-unittest-config.yml
@@ -26,21 +26,6 @@ parameters:
     default: false
 
 commands:
-  setup_go_test:
-    steps:
-      - restore_cache:
-          keys:
-            - v1-linux-go-modules-{{ checksum "go.sum" }}
-      - run:
-          name: "Tidy and Download Go Modules"
-          command: |
-            go mod tidy
-            go mod download
-      - save_cache:
-          key: v1-linux-go-modules-{{ checksum "go.sum" }}
-          paths:
-            - /usr/local/pkg/mod
-
   setup_cpp_test:
     steps:
       - run:
@@ -57,6 +42,7 @@ commands:
           name: "Go Test"
           command: |
             set +e
+            go mod tidy
             echo "Running unit tests..."
             go test -mod=readonly -timeout=30m -v -short ./pkg/... ./contrib/...
 
@@ -95,7 +81,6 @@ jobs:
     resource_class: "large"
     steps:
       - checkout
-      - setup_go_test
       - run_go_test
 
   linux_cpp_ut:

--- a/.circleci/path-filtering/unittest.conf
+++ b/.circleci/path-filtering/unittest.conf
@@ -2,10 +2,10 @@ api/.* run_go_ut true
 cmd/.* run_go_ut true
 pkg/.* run_go_ut true
 contrib/.* run_go_ut true
-.circleci/unittest-config.yml run_go_ut true
+.circleci/lite-unittest-config.yml run_go_ut true
 bazel/.* run_cpp_ut true
 engine/.* run_cpp_ut true
 .bazelrc run_cpp_ut true
 .bazeliskrc run_cpp_ut true
 MODULE.bazel run_cpp_ut true
-.circleci/unittest-config.yml run_cpp_ut true
+.circleci/lite-unittest-config.yml run_cpp_ut true

--- a/.circleci/unittest-config.yml
+++ b/.circleci/unittest-config.yml
@@ -26,6 +26,24 @@ parameters:
     default: false
 
 commands:
+  setup_go_test:
+    description: "Restores Go module cache, downloads dependencies, and saves the cache for both Linux and macOS."
+    steps:
+      - restore_cache:
+          keys:
+            - v1-go-modules-{{ checksum "go.sum" }}
+            - v1-go-modules-
+
+      - run:
+          name: "Download Go Modules"
+          command: go mod download
+
+      - save_cache:
+          key: v1-go-modules-{{ checksum "go.sum" }}
+          paths:
+            - /go/pkg/mod   # For Linux Docker executor
+            - ~/go/pkg/mod  # For macOS executor
+
   setup_cpp_test:
     steps:
       - run:
@@ -87,6 +105,7 @@ jobs:
     resource_class: << parameters.resource_class >>
     steps:
       - checkout
+      - setup_go_test
       - run_go_test
 
   linux_cpp_ut:
@@ -119,6 +138,7 @@ jobs:
           name: "Install homebrew dependencies"
           command: |
             brew install wget go
+      - setup_go_test
       - run_go_test
 
   macOS_cpp_ut:

--- a/.circleci/unittest-config.yml
+++ b/.circleci/unittest-config.yml
@@ -31,8 +31,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v1-go-modules-{{ checksum "go.sum" }}
-            - v1-go-modules-
+            - v2-go-modules-{{ checksum "go.sum" }}
+            - v2-go-modules-
 
       - run:
           name: "Download Go Modules"
@@ -41,7 +41,7 @@ commands:
             go mod download
 
       - save_cache:
-          key: v1-go-modules-{{ checksum "go.sum" }}
+          key: v2-go-modules-{{ checksum "go.sum" }}
           paths:
             - /go/pkg/mod   # For Linux Docker executor
             - ~/go/pkg/mod  # For macOS executor

--- a/.circleci/unittest-config.yml
+++ b/.circleci/unittest-config.yml
@@ -161,13 +161,6 @@ jobs:
       xcode: 16.0.0
     resource_class: m4pro.medium
     steps:
-      - run:
-          name: Cancel build after set time
-          background: true
-          command: |
-            sleep 3600
-            echo "Canceling workflow as too much time has elapsed"
-            curl -X POST --header "Content-Type: application/json" "https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/cancel?circle-token=${BUILD_TIMER_TOKEN}"
       - checkout
       - run:
           name: "Install homebrew dependencies"

--- a/.circleci/unittest-config.yml
+++ b/.circleci/unittest-config.yml
@@ -185,7 +185,7 @@ workflows:
       - linux_go_ut:
           matrix:
             parameters:
-              resource_class: ["2xlarge", "arm-xlarge"]
+              resource_class: ["large", "arm.large"]
       - macOS_go_ut
   run_cpp_ut:
     when: << pipeline.parameters.run_cpp_ut >>
@@ -193,5 +193,5 @@ workflows:
       - linux_cpp_ut:
           matrix:
             parameters:
-              resource_class: ["2xlarge", "arm-xlarge"]
+              resource_class: ["2xlarge", "arm.2xlarge"]
       - macOS_cpp_ut

--- a/.circleci/unittest-config.yml
+++ b/.circleci/unittest-config.yml
@@ -36,7 +36,9 @@ commands:
 
       - run:
           name: "Download Go Modules"
-          command: go mod download
+          command: |
+            go mod tidy
+            go mod download
 
       - save_cache:
           key: v1-go-modules-{{ checksum "go.sum" }}
@@ -60,9 +62,8 @@ commands:
           name: "Go Test"
           command: |
             set +e
-            go mod tidy
             echo "Running unit tests..."
-            go test -timeout=30m -v -short ./pkg/... ./contrib/...
+            go test -mod=readonly -timeout=30m -v -short ./pkg/... ./contrib/...
 
   run_cpp_test:
     description: "Run cpp tests and collect artifacts on fail"

--- a/.circleci/unittest-config.yml
+++ b/.circleci/unittest-config.yml
@@ -31,18 +31,28 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v2-go-modules-{{ checksum "go.sum" }}
-            - v2-go-modules-
+            - v3-go-modules-{{ checksum "go.sum" }}
+            - v3-go-modules-
 
       - run:
           name: "Download Go Modules"
           command: |
+            echo "================================================="
+            echo "DEBUG: The Go environment path (GOPATH) is: $(go env GOPATH)"
+            echo "================================================="
+
             go mod tidy
             go mod download
 
+            echo "================================================="
+            echo "DEBUG: Listing contents of the real module cache directory..."
+            ls -la "$(go env GOPATH)/pkg/mod"
+            echo "================================================="
+
       - save_cache:
-          key: v2-go-modules-{{ checksum "go.sum" }}
+          key: v3-go-modules-{{ checksum "go.sum" }}
           paths:
+            - "$(go env GOPATH)/pkg/mod"
             - /go/pkg/mod   # For Linux Docker executor
             - ~/go/pkg/mod  # For macOS executor
 

--- a/.circleci/unittest-config.yml
+++ b/.circleci/unittest-config.yml
@@ -31,30 +31,20 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v3-go-modules-{{ checksum "go.sum" }}
-            - v3-go-modules-
+            - v4-go-modules-{{ checksum "go.sum" }}
+            - v4-go-modules-
 
       - run:
           name: "Download Go Modules"
           command: |
-            echo "================================================="
-            echo "DEBUG: The Go environment path (GOPATH) is: $(go env GOPATH)"
-            echo "================================================="
-
             go mod tidy
             go mod download
 
-            echo "================================================="
-            echo "DEBUG: Listing contents of the real module cache directory..."
-            ls -la "$(go env GOPATH)/pkg/mod"
-            echo "================================================="
-
       - save_cache:
-          key: v3-go-modules-{{ checksum "go.sum" }}
+          key: v4-go-modules-{{ checksum "go.sum" }}
           paths:
-            - "$(go env GOPATH)/pkg/mod"
-            - /go/pkg/mod   # For Linux Docker executor
-            - ~/go/pkg/mod  # For macOS executor
+            - /usr/local/pkg/mod   # For Linux Docker executor
+            - /Users/distiller/go/pkg/mod  # For macOS executor
 
   setup_cpp_test:
     steps:

--- a/.circleci/unittest-config.yml
+++ b/.circleci/unittest-config.yml
@@ -27,24 +27,28 @@ parameters:
 
 commands:
   setup_go_test:
-    description: "Restores Go module cache, downloads dependencies, and saves the cache for both Linux and macOS."
+    description: "Set up Go environment for a specific OS."
+    parameters:
+      os_identifier:
+        type: string
+        description: "An identifier for the OS, used in the cache key (e.g., 'linux', 'macos')."
+      cache_path:
+        type: string
+        description: "The absolute path to the Go module cache directory."
     steps:
       - restore_cache:
           keys:
-            - v4-go-modules-{{ checksum "go.sum" }}
-            - v4-go-modules-
-
+            - v1-<< parameters.os_identifier >>-go-modules-{{ checksum "go.sum" }}
+            - v1-<< parameters.os_identifier >>-go-modules-
       - run:
-          name: "Download Go Modules"
+          name: "Tidy and Download Go Modules"
           command: |
             go mod tidy
             go mod download
-
       - save_cache:
-          key: v4-go-modules-{{ checksum "go.sum" }}
+          key: v1-<< parameters.os_identifier >>-go-modules-{{ checksum "go.sum" }}
           paths:
-            - /usr/local/pkg/mod   # For Linux Docker executor
-            - /Users/distiller/go/pkg/mod  # For macOS executor
+            - << parameters.cache_path >>
 
   setup_cpp_test:
     steps:
@@ -110,7 +114,9 @@ jobs:
     resource_class: << parameters.resource_class >>
     steps:
       - checkout
-      - setup_go_test
+      - setup_go_test:
+          os_identifier: linux
+          cache_path: /usr/local/pkg/mod
       - run_go_test
 
   linux_cpp_ut:
@@ -145,7 +151,9 @@ jobs:
           name: "Install homebrew dependencies"
           command: |
             brew install wget go
-      - setup_go_test
+      - setup_go_test:
+          os_identifier: macos
+          cache_path: /Users/distiller/go/pkg/mod
       - run_go_test
 
   macOS_cpp_ut:

--- a/.circleci/unittest-config.yml
+++ b/.circleci/unittest-config.yml
@@ -61,11 +61,11 @@ commands:
           command: |
             set +e
             go mod tidy
-            echo "Running tests without coverage..."
+            echo "Running unit tests..."
             go test -timeout=30m -v -short ./pkg/... ./contrib/...
 
   run_cpp_test:
-    description: "Run cpp tests and collect artifacts"
+    description: "Run cpp tests and collect artifacts on fail"
     parameters:
       extra_bazel_args:
         type: string
@@ -80,7 +80,7 @@ commands:
             set +e
             declare -i test_status
 
-            echo "Running tests without coverage..."
+            echo "Running unit tests..."
             bazelisk --host_jvm_args=-Xmx8g test //engine/... \
                 << parameters.extra_bazel_args >> \
                 --jobs=auto \
@@ -91,8 +91,12 @@ commands:
             test_status=${PIPESTATUS[0]}
 
             sh ../devtools/rename-junit-xml.sh
-            find bazel-bin/ << parameters.find_executable_flag >> -type f -name "*_test" -print0 | xargs -0 tar -cvzf test_binary.tar.gz
-            find bazel-testlogs/ -type f -name "test.log" -print0 | xargs -0 tar -cvzf test_logs.tar.gz
+            if [ ${test_status} -ne 0 ]; then
+              echo "Tests failed. Archiving binaries and logs..."
+              find bazel-bin/ << parameters.find_executable_flag >> -type f -name "*_test" -print0 | xargs -0 tar -cvzf test_binary.tar.gz
+              find bazel-testlogs/ -type f -name "test.log" -print0 | xargs -0 tar -cvzf test_logs.tar.gz
+            fi
+
             exit ${test_status}
 
 jobs:
@@ -124,8 +128,10 @@ jobs:
       - store_test_results:
           path: test-results
       - store_artifacts:
+          when: on_fail
           path: test_binary.tar.gz
       - store_artifacts:
+          when: on_fail
           path: test_logs.tar.gz
 
   macOS_go_ut:
@@ -166,8 +172,10 @@ jobs:
       - store_test_results:
           path: test-results
       - store_artifacts:
+          when: on_fail
           path: test_binary.tar.gz
       - store_artifacts:
+          when: on_fail
           path: test_logs.tar.gz
 
 workflows:

--- a/.github/workflows/trigger-ci-full-ut.yml
+++ b/.github/workflows/trigger-ci-full-ut.yml
@@ -1,0 +1,31 @@
+name: Trigger CircleCI Full Unit Test for Forked & Labeled PR
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  trigger-circleci:
+    runs-on: ubuntu-latest
+    # This job only runs if the label that was just added is exactly "run-ci-full".
+    if: github.event.label.name == 'run-ci-cov'
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Trigger CircleCI Pipeline
+        run: |
+          echo "Label 'run-ci-full' was added to PR #${{ github.event.pull_request.number }}. Triggering CircleCI pipeline..."
+
+          curl -X POST \
+            --url "https://circleci.com/api/v2/project/github/secretflow/scql/pipeline/run" \
+            --header "Content-Type: application/json" \
+            --header "Circle-Token: ${{ secrets.CCI_TOKEN }}" \
+            --data '{"definition_id":"ee28d7c2-ef66-4a57-bc90-6895e2b55f14","config":{"branch":"main"},"checkout":{"branch":"pull/${{ github.event.pull_request.number }}/head"}}'
+      - name: Remove Label from PR
+        run: |
+          echo "Removing 'run-ci-full' label from PR #${{ github.event.pull_request.number }}..."
+
+          curl -s -X DELETE \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/run-ci-full"

--- a/.github/workflows/trigger-ci-lite-ut.yml
+++ b/.github/workflows/trigger-ci-lite-ut.yml
@@ -1,4 +1,4 @@
-name: Trigger CircleCI Unit Test for Forked & Labeled PR
+name: Trigger CircleCI Lite Unit Test for Forked & Labeled PR
 
 on:
   pull_request_target:


### PR DESCRIPTION
- Unit Test
   - Go unit tests are much faster than C++ compilation and linking, so `linux_go_ut` can try using `large` resources
   - C++ unit tests only package binaries and logs when tests fail
   - Consider pinning Docker image versions, but the last scql-ci update was 5 months ago (not implemented)
   - Use lite unit tests (linux/amd64 only) by default; trigger full tests (linux/amd64, linux/arm64, macOS) as needed
- Coverage Test
   - Only package binaries and logs on failure
   - Consider installing lcov into scql-ci (not implemented)