### PR TITLE
feat: add timestamp literal optimizer

### DIFF
--- a/pkg/interpreter/interpreter.go
+++ b/pkg/interpreter/interpreter.go
@@ -65,6 +65,7 @@ func (intr *Interpreter) Compile(ctx context.Context, req *pb.CompileQueryReques
 	sctx.GetSessionVars().PlanID = 0
 	sctx.GetSessionVars().PlanColumnID = 0
 	sctx.GetSessionVars().CurrentDB = req.GetDbName()
+	sctx.GetSessionVars().CreatedAt = req.GetCreatedAt().AsTime()
 
 	lp, _, err := core.BuildLogicalPlanWithOptimization(ctx, sctx, stmts[0], is)
 	if err != nil {

--- a/pkg/interpreter/translator/translator_ccl_input_for_test.go
+++ b/pkg/interpreter/translator/translator_ccl_input_for_test.go
@@ -252,6 +252,12 @@ FROM alice.tbl_0 as ta JOIN bob.tbl_0 as tb ON ta.join_int_0 = tb.join_int_0`, `
 9 -> 10 [label = "t_14:{plain_datetime_0:PRIVATE:DATETIME}"]
 }`, ``, testConf{groupThreshold: 0, batched: false},
 	},
+	{`SELECT ta.plain_timestamp_0 from alice.tbl_0 as ta where ta.plain_timestamp_0 > '2025-04-23 12:25:42'`, `digraph G {
+0 [label="runsql:{in:[],out:[Out:{t_0,},],attr:[sql:select ta.plain_timestamp_0 from alice.tbl_0 as ta where ta.plain_timestamp_0>'2025-04-23 12:25:42+08:00';,table_refs:[alice.tbl_0],],party:[alice,]}"]
+1 [label="publish:{in:[In:{t_0,},],out:[Out:{t_1,},],attr:[],party:[alice,]}"]
+0 -> 1 [label = "t_0:{plain_timestamp_0:PRIVATE:TIMESTAMP}"]
+}`, ``, testConf{groupThreshold: 0, batched: false},
+	},
 	{`SELECT ta.join_int_0, ta.plain_datetime_0 from alice.tbl_0 as ta right join bob.tbl_0 as tb on ta.join_int_0 = tb.join_int_0 where ta.plain_datetime_0 > str_to_date('2025-06-05', '%Y-%m-%d')`, `digraph G {
 0 [label="runsql:{in:[],out:[Out:{t_0,t_1,},],attr:[sql:select ta.join_int_0,ta.plain_datetime_0 from alice.tbl_0 as ta;,table_refs:[alice.tbl_0],],party:[alice,]}"]
 1 [label="runsql:{in:[],out:[Out:{t_2,},],attr:[sql:select tb.join_int_0 from bob.tbl_0 as tb;,table_refs:[bob.tbl_0],],party:[bob,]}"]

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -42,6 +42,7 @@ const (
 	flagPushDownTopN
 	flagJoinReOrder
 	flagDoubleCheckEliminateProjection
+	flagPatchTimeZone
 )
 
 var optRuleList = []logicalOptRule{
@@ -59,6 +60,7 @@ var optRuleList = []logicalOptRule{
 	&optPlaceHolder{},
 	&optPlaceHolder{},
 	&projectionEliminator{},
+	&timeZonePatcher{},
 }
 
 // logicalOptRule means a logical optimizing rule, which contains decorrelate, ppd, column pruning, etc.
@@ -120,7 +122,7 @@ func BuildLogicalPlanWithOptimization(ctx context.Context, sctx sessionctx.Conte
 		return nil, nil, err
 	}
 
-	lp, err := logicalOptimize(ctx, builder.optFlag|flagDoubleCheckEliminateProjection|flagPrunColumnsDouble, p.(LogicalPlan))
+	lp, err := logicalOptimize(ctx, builder.optFlag|flagDoubleCheckEliminateProjection|flagPrunColumnsDouble|flagPatchTimeZone, p.(LogicalPlan))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/planner/core/rule_patch_timezone.go
+++ b/pkg/planner/core/rule_patch_timezone.go
@@ -1,0 +1,247 @@
+// Copyright 2025 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package core
+
+import (
+	"context"
+	"regexp"
+	"time"
+
+	"github.com/secretflow/scql/pkg/expression"
+	"github.com/secretflow/scql/pkg/parser/ast"
+	"github.com/secretflow/scql/pkg/parser/mysql"
+	"github.com/secretflow/scql/pkg/types"
+)
+
+// timeZonePatcher is an optimization rule that adds timezone information
+// to timestamp literals when they are being compared to timestamp columns
+type timeZonePatcher struct{}
+
+func (t *timeZonePatcher) optimize(ctx context.Context, lp LogicalPlan) (LogicalPlan, error) {
+	// Get the session context from the logical plan
+	sctx := lp.SCtx()
+	if sctx == nil {
+		return lp, nil
+	}
+	// Get the createdAt time from the session context
+	createdAt := sctx.GetSessionVars().CreatedAt
+	if createdAt.IsZero() {
+		return lp, nil
+	}
+	// Create and apply the logical plan timestamp visitor
+	visitor := newLogicalPlanTimestampVisitor(createdAt)
+	visitor.visit(lp)
+	return lp, nil
+}
+func (t *timeZonePatcher) name() string {
+	return "time_zone_patch"
+}
+
+// logicalPlanTimestampVisitor is a visitor that adds timezone information to timestamp literals
+// in the logical plan directly, using the type information available in the logical plan
+type logicalPlanTimestampVisitor struct {
+	createdAt time.Time
+}
+
+// newLogicalPlanTimestampVisitor creates a new logicalPlanTimestampVisitor
+func newLogicalPlanTimestampVisitor(createdAt time.Time) *logicalPlanTimestampVisitor {
+	return &logicalPlanTimestampVisitor{
+		createdAt: createdAt,
+	}
+}
+
+// visit implements a recursive traversal of the logical plan to modify timestamp literals
+func (lptv *logicalPlanTimestampVisitor) visit(lp LogicalPlan) {
+	for _, child := range lp.Children() {
+		lptv.visit(child)
+	}
+	lptv.processNode(lp)
+}
+
+// processNode processes a single logical plan node to modify timestamp literals
+func (lptv *logicalPlanTimestampVisitor) processNode(lp LogicalPlan) {
+	switch node := lp.(type) {
+	case *LogicalSelection:
+		for _, expr := range node.Conditions {
+			lptv.processExpression(expr, logicalPlanContextInfo{})
+		}
+	case *LogicalProjection:
+		for _, expr := range node.Exprs {
+			lptv.processExpression(expr, logicalPlanContextInfo{})
+		}
+	case *LogicalAggregation:
+		// Process aggregation function arguments and group by items
+		for _, aggFunc := range node.AggFuncs {
+			for _, arg := range aggFunc.Args {
+				lptv.processExpression(arg, logicalPlanContextInfo{})
+			}
+		}
+		for _, item := range node.GroupByItems {
+			lptv.processExpression(item, logicalPlanContextInfo{})
+		}
+	case *LogicalWindow:
+		// Process window function arguments, partition by, order by, and frame bounds
+		for _, windowFunc := range node.WindowFuncDescs {
+			for _, arg := range windowFunc.Args {
+				lptv.processExpression(arg, logicalPlanContextInfo{})
+			}
+		}
+		for _, item := range node.PartitionBy {
+			lptv.processExpression(item.Col, logicalPlanContextInfo{})
+		}
+		for _, item := range node.OrderBy {
+			lptv.processExpression(item.Col, logicalPlanContextInfo{})
+		}
+		// Process frame bounds if present
+		if node.Frame != nil {
+			if node.Frame.Start != nil {
+				for _, calcFunc := range node.Frame.Start.CalcFuncs {
+					lptv.processExpression(calcFunc, logicalPlanContextInfo{})
+				}
+			}
+			if node.Frame.End != nil {
+				for _, calcFunc := range node.Frame.End.CalcFuncs {
+					lptv.processExpression(calcFunc, logicalPlanContextInfo{})
+				}
+			}
+		}
+	case *LogicalSort:
+		// Process sort expressions
+		for _, item := range node.ByItems {
+			lptv.processExpression(item.Expr, logicalPlanContextInfo{})
+		}
+	case *LogicalApply:
+		// Process correlated columns
+		for _, col := range node.CorCols {
+			lptv.processExpression(&col.Column, logicalPlanContextInfo{})
+		}
+		if join, ok := lp.(*LogicalJoin); ok {
+			for _, eqCond := range join.EqualConditions {
+				lptv.processExpression(eqCond, logicalPlanContextInfo{})
+			}
+			for _, leftCond := range join.LeftConditions {
+				lptv.processExpression(leftCond, logicalPlanContextInfo{})
+			}
+			for _, rightCond := range join.RightConditions {
+				lptv.processExpression(rightCond, logicalPlanContextInfo{})
+			}
+			for _, otherCond := range join.OtherConditions {
+				lptv.processExpression(otherCond, logicalPlanContextInfo{})
+			}
+		}
+		// In SCQL, join operations typically only involve column-to-column equality comparisons
+		// case *LogicalJoin:
+		// 	// Process all join conditions
+		// 	for _, eqCond := range node.EqualConditions {
+		// 		lptv.processExpression(eqCond, logicalPlanContextInfo{})
+		// 	}
+		// 	for _, leftCond := range node.LeftConditions {
+		// 		lptv.processExpression(leftCond, logicalPlanContextInfo{})
+		// 	}
+		// 	for _, rightCond := range node.RightConditions {
+		// 		lptv.processExpression(rightCond, logicalPlanContextInfo{})
+		// 	}
+		// 	for _, otherCond := range node.OtherConditions {
+		// 		lptv.processExpression(otherCond, logicalPlanContextInfo{})
+		// 	}
+	}
+}
+
+// processExpression processes a single expression to modify timestamp literals
+func (lptv *logicalPlanTimestampVisitor) processExpression(expr expression.Expression, ctx logicalPlanContextInfo) {
+	// If this is a scalar function, we need to check if it's a timestamp comparison
+	// and process its arguments with the appropriate context
+	if scalarFunc, ok := expr.(*expression.ScalarFunction); ok {
+		isTimestampComparison := lptv.isTimestampComparison(expr)
+		newCtx := logicalPlanContextInfo{
+			inTimestampComparison: isTimestampComparison,
+		}
+		lptv.processExpressions(scalarFunc.GetArgs(), newCtx)
+		return
+	}
+	// If this is a constant value expression, check if it's a timestamp literal we need to modify
+	if constant, ok := expr.(*expression.Constant); ok {
+		lptv.processConstant(constant, ctx)
+		return
+	}
+}
+
+// processExpressions processes a slice of expressions to modify timestamp literals
+func (lptv *logicalPlanTimestampVisitor) processExpressions(exprs []expression.Expression, ctx logicalPlanContextInfo) {
+	for _, expr := range exprs {
+		lptv.processExpression(expr, ctx)
+	}
+}
+
+// logicalPlanContextInfo tracks information about the current context during logical plan traversal
+type logicalPlanContextInfo struct {
+	// Whether we're in a comparison operation with a timestamp column
+	inTimestampComparison bool
+}
+
+// isTimestampComparison checks if an expression is a comparison with a timestamp column
+func (lptv *logicalPlanTimestampVisitor) isTimestampComparison(expr expression.Expression) bool {
+	if scalarFunc, ok := expr.(*expression.ScalarFunction); ok {
+		switch scalarFunc.FuncName.L {
+		case ast.EQ, ast.NE, ast.LT, ast.LE, ast.GT, ast.GE:
+			for _, arg := range scalarFunc.GetArgs() {
+				if lptv.isTimestampColumn(arg) {
+					return true
+				}
+			}
+		case ast.In:
+			args := scalarFunc.GetArgs()
+			if len(args) > 0 && lptv.isTimestampColumn(args[0]) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isTimestampColumn checks if an expression represents a timestamp column
+func (lptv *logicalPlanTimestampVisitor) isTimestampColumn(expr expression.Expression) bool {
+	if col, ok := expr.(*expression.Column); ok {
+		return col.RetType.Tp == mysql.TypeTimestamp
+	}
+	return false
+}
+
+// isTimestampWithoutTimezone checks if a string is a timestamp format without timezone
+func (lptv *logicalPlanTimestampVisitor) isTimestampWithoutTimezone(s string) bool {
+	// Check if it matches timestamp pattern like "2023-10-01 08:30:00" or "2023-10-01T08:30:00"
+	timestampPattern := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}$`)
+	// Check if it already has timezone information
+	hasTimezonePattern := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}([+-]\d{2}:\d{2}|Z)$`)
+	return timestampPattern.MatchString(s) && !hasTimezonePattern.MatchString(s)
+}
+
+// processConstant processes a constant value to modify timestamp literals
+func (lptv *logicalPlanTimestampVisitor) processConstant(constant *expression.Constant, ctx logicalPlanContextInfo) {
+	if constant.Value.Kind() == types.KindString {
+		strValue := constant.Value.GetString()
+		if ctx.inTimestampComparison {
+			if lptv.isTimestampWithoutTimezone(strValue) {
+				// Add timezone from createdAt
+				timezoneStr := lptv.createdAt.Format("-07:00")
+				if timezoneStr[0] != '-' && timezoneStr[0] != '+' {
+					timezoneStr = "+" + timezoneStr
+				}
+				newValue := strValue + timezoneStr
+				// Update the constant with the new value
+				constant.Value.SetString(newValue)
+			}
+		}
+	}
+}

--- a/pkg/planner/core/rule_patch_timezone_test.go
+++ b/pkg/planner/core/rule_patch_timezone_test.go
@@ -1,0 +1,527 @@
+// Copyright 2025 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package core
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/secretflow/scql/pkg/expression"
+	"github.com/secretflow/scql/pkg/infoschema"
+	"github.com/secretflow/scql/pkg/parser"
+	"github.com/secretflow/scql/pkg/parser/model"
+	"github.com/secretflow/scql/pkg/parser/mysql"
+	"github.com/secretflow/scql/pkg/sessionctx"
+	"github.com/secretflow/scql/pkg/sessionctx/stmtctx"
+	"github.com/secretflow/scql/pkg/types"
+)
+
+// TestLogicalPlanTimestampVisitor tests the logical plan timestamp visitor
+func TestLogicalPlanTimestampVisitor(t *testing.T) {
+	createdAt := time.Date(2023, 10, 1, 8, 30, 0, 0, time.FixedZone("UTC+8", 8*3600))
+	visitor := newLogicalPlanTimestampVisitor(createdAt)
+	// Test case 1: isTimestampWithoutTimezone should correctly identify timestamp strings
+	t.Run("IsTimestampWithoutTimezone", func(t *testing.T) {
+		// Should match timestamps without timezone
+		assert.True(t, visitor.isTimestampWithoutTimezone("2023-10-01 08:30:00"))
+		assert.True(t, visitor.isTimestampWithoutTimezone("2023-10-01T08:30:00"))
+		// Should not match timestamps with timezone
+		assert.False(t, visitor.isTimestampWithoutTimezone("2023-10-01 08:30:00+08:00"))
+		assert.False(t, visitor.isTimestampWithoutTimezone("2023-10-01T08:30:00Z"))
+		// Should not match other strings
+		assert.False(t, visitor.isTimestampWithoutTimezone("not a timestamp"))
+		assert.False(t, visitor.isTimestampWithoutTimezone("2023-10-01"))
+	})
+	// Test case 2: processConstant should add timezone when in timestamp comparison context
+	t.Run("ProcessConstantInTimestampComparison", func(t *testing.T) {
+		// Create a constant with timestamp value
+		timestampConst := &expression.Constant{
+			Value: types.NewStringDatum("2023-10-01 08:30:00"),
+		}
+		// Process with timestamp comparison context
+		ctx := logicalPlanContextInfo{inTimestampComparison: true}
+		visitor.processConstant(timestampConst, ctx)
+		// Check that the timezone was appended
+		expected := "2023-10-01 08:30:00+08:00"
+		assert.Equal(t, expected, timestampConst.Value.GetString())
+	})
+	// Test case 3: processConstant should not add timezone when not in timestamp comparison context
+	t.Run("ProcessConstantNotInTimestampComparison", func(t *testing.T) {
+		// Create a constant with timestamp value
+		timestampConst := &expression.Constant{
+			Value: types.NewStringDatum("2023-10-01 08:30:00"),
+		}
+		// Process with non-timestamp comparison context
+		ctx := logicalPlanContextInfo{inTimestampComparison: false}
+		visitor.processConstant(timestampConst, ctx)
+		// Check that the timezone was NOT appended
+		expected := "2023-10-01 08:30:00"
+		assert.Equal(t, expected, timestampConst.Value.GetString())
+	})
+	// Test case 4: processConstant should not modify non-string constants
+	t.Run("ProcessNonStringConstant", func(t *testing.T) {
+		// Create a constant with integer value
+		intConst := &expression.Constant{
+			Value: types.NewIntDatum(123),
+		}
+		// Process with timestamp comparison context
+		ctx := logicalPlanContextInfo{inTimestampComparison: true}
+		visitor.processConstant(intConst, ctx)
+		// Check that the value was not modified
+		expected := int64(123)
+		assert.Equal(t, expected, intConst.Value.GetInt64())
+	})
+	// Test case 5: isTimestampColumn should correctly identify timestamp columns
+	t.Run("IsTimestampColumn", func(t *testing.T) {
+		// Create a column with timestamp type
+		timestampCol := &expression.Column{
+			RetType: types.NewFieldType(mysql.TypeTimestamp),
+		}
+		// Create a column with varchar type
+		varcharCol := &expression.Column{
+			RetType: types.NewFieldType(mysql.TypeVarchar),
+		}
+		// Check that timestamp column is identified correctly
+		assert.True(t, visitor.isTimestampColumn(timestampCol))
+		// Check that non-timestamp column is identified correctly
+		assert.False(t, visitor.isTimestampColumn(varcharCol))
+	})
+}
+
+// TestTimestampLiteralOptimizer tests the complete timestamp literal optimization functionality
+func TestTimestampLiteralOptimizer(t *testing.T) {
+	// Create a session context with createdAt time
+	sctx := sessionctx.NewContext()
+	createdAt := time.Date(2023, 10, 1, 8, 30, 0, 0, time.FixedZone("UTC+8", 8*3600))
+	sctx.GetSessionVars().CreatedAt = createdAt
+	sctx.GetSessionVars().StmtCtx = &stmtctx.StatementContext{}
+	sctx.GetSessionVars().PlanID = 0
+	sctx.GetSessionVars().PlanColumnID = 0
+	// Create a simple infoschema for testing
+	tableInfos := map[string][]*model.TableInfo{
+		"test": {
+			{
+				Name: model.NewCIStr("orders"),
+				Columns: []*model.ColumnInfo{
+					{
+						Name:      model.NewCIStr("created_at"),
+						FieldType: *types.NewFieldType(mysql.TypeTimestamp),
+					},
+					{
+						Name:      model.NewCIStr("status"),
+						FieldType: *types.NewFieldType(mysql.TypeVarchar),
+					},
+				},
+			},
+		},
+	}
+	is := infoschema.MockInfoSchema(tableInfos)
+	// Test case 1: Simple equality comparison with timestamp column
+	t.Run("SimpleEqualityComparison", func(t *testing.T) {
+		p := parser.New()
+		stmts, _, err := p.Parse("SELECT * FROM test.orders WHERE created_at = '2023-10-01 08:30:00'", "", "")
+		assert.NoError(t, err)
+		assert.Len(t, stmts, 1)
+		// Build logical plan without optimization
+		plan1, _, err := BuildLogicalPlan(context.Background(), sctx, stmts[0], is)
+		assert.NoError(t, err)
+		assert.NotNil(t, plan1)
+		lp1, ok := plan1.(LogicalPlan)
+		assert.True(t, ok)
+		// Find constants in the non-optimized plan
+		constants1 := findConstantsInPlan(lp1)
+		assert.GreaterOrEqual(t, len(constants1), 1)
+		if len(constants1) > 0 {
+			assert.Equal(t, "2023-10-01 08:30:00", constants1[0].Value.GetString())
+		}
+		// Build logical plan with optimization
+		plan2, _, err := BuildLogicalPlanWithOptimization(context.Background(), sctx, stmts[0], is)
+		assert.NoError(t, err)
+		assert.NotNil(t, plan2)
+		// Find constants in the optimized plan
+		constants2 := findConstantsInPlan(plan2)
+		assert.GreaterOrEqual(t, len(constants2), 1)
+		if len(constants2) > 0 {
+			assert.Equal(t, "2023-10-01 08:30:00+08:00", constants2[0].Value.GetString())
+		}
+	})
+	// Test case 2: IN clause with timestamp column
+	t.Run("InClauseComparison", func(t *testing.T) {
+		p := parser.New()
+		stmts, _, err := p.Parse("SELECT * FROM test.orders WHERE created_at IN ('2023-10-01 08:30:00', '2023-10-02 09:00:00')", "", "")
+		assert.NoError(t, err)
+		assert.Len(t, stmts, 1)
+		// Build logical plan without optimization
+		plan1, _, err := BuildLogicalPlan(context.Background(), sctx, stmts[0], is)
+		assert.NoError(t, err)
+		assert.NotNil(t, plan1)
+		lp1, ok := plan1.(LogicalPlan)
+		assert.True(t, ok)
+		// Find constants in the non-optimized plan
+		constants1 := findConstantsInPlan(lp1)
+		assert.GreaterOrEqual(t, len(constants1), 2)
+		if len(constants1) >= 2 {
+			assert.Equal(t, "2023-10-01 08:30:00", constants1[0].Value.GetString())
+			assert.Equal(t, "2023-10-02 09:00:00", constants1[1].Value.GetString())
+		}
+		// Build logical plan with optimization
+		plan2, _, err := BuildLogicalPlanWithOptimization(context.Background(), sctx, stmts[0], is)
+		assert.NoError(t, err)
+		assert.NotNil(t, plan2)
+		// Find constants in the optimized plan
+		constants2 := findConstantsInPlan(plan2)
+		assert.GreaterOrEqual(t, len(constants2), 2)
+		if len(constants2) >= 2 {
+			assert.Equal(t, "2023-10-01 08:30:00+08:00", constants2[0].Value.GetString())
+			assert.Equal(t, "2023-10-02 09:00:00+08:00", constants2[1].Value.GetString())
+		}
+	})
+	// Test case 3: Timestamp with existing timezone should not be modified
+	t.Run("TimestampWithExistingTimezone", func(t *testing.T) {
+		p := parser.New()
+		stmts, _, err := p.Parse("SELECT * FROM test.orders WHERE created_at = '2023-10-01 08:30:00+08:00'", "", "")
+		assert.NoError(t, err)
+		assert.Len(t, stmts, 1)
+		// Build logical plan without optimization
+		plan1, _, err := BuildLogicalPlan(context.Background(), sctx, stmts[0], is)
+		assert.NoError(t, err)
+		assert.NotNil(t, plan1)
+		lp1, ok := plan1.(LogicalPlan)
+		assert.True(t, ok)
+		// Find constants in the non-optimized plan
+		constants1 := findConstantsInPlan(lp1)
+		assert.GreaterOrEqual(t, len(constants1), 1)
+		if len(constants1) > 0 {
+			assert.Equal(t, "2023-10-01 08:30:00+08:00", constants1[0].Value.GetString())
+		}
+		// Build logical plan with optimization
+		plan2, _, err := BuildLogicalPlanWithOptimization(context.Background(), sctx, stmts[0], is)
+		assert.NoError(t, err)
+		assert.NotNil(t, plan2)
+		// Find constants in the optimized plan
+		constants2 := findConstantsInPlan(plan2)
+		assert.GreaterOrEqual(t, len(constants2), 1)
+		if len(constants2) > 0 {
+			assert.Equal(t, "2023-10-01 08:30:00+08:00", constants2[0].Value.GetString())
+		}
+	})
+	// Test case 4: Non-timestamp column should not be modified
+	t.Run("NonTimestampColumn", func(t *testing.T) {
+		p := parser.New()
+		stmts, _, err := p.Parse("SELECT * FROM test.orders WHERE status = '2023-10-01 08:30:00'", "", "")
+		assert.NoError(t, err)
+		assert.Len(t, stmts, 1)
+		// Build logical plan without optimization
+		plan1, _, err := BuildLogicalPlan(context.Background(), sctx, stmts[0], is)
+		assert.NoError(t, err)
+		assert.NotNil(t, plan1)
+		lp1, ok := plan1.(LogicalPlan)
+		assert.True(t, ok)
+		// Find constants in the non-optimized plan
+		constants1 := findConstantsInPlan(lp1)
+		assert.GreaterOrEqual(t, len(constants1), 1)
+		if len(constants1) > 0 {
+			assert.Equal(t, "2023-10-01 08:30:00", constants1[0].Value.GetString())
+		}
+		// Build logical plan with optimization
+		plan2, _, err := BuildLogicalPlanWithOptimization(context.Background(), sctx, stmts[0], is)
+		assert.NoError(t, err)
+		assert.NotNil(t, plan2)
+		// Find constants in the optimized plan
+		constants2 := findConstantsInPlan(plan2)
+		assert.GreaterOrEqual(t, len(constants2), 1)
+		if len(constants2) > 0 {
+			assert.Equal(t, "2023-10-01 08:30:00", constants2[0].Value.GetString())
+		}
+	})
+	// Test case 5: Timestamp comparison in projection
+	t.Run("TimestampComparisonInProjection", func(t *testing.T) {
+		p := parser.New()
+		stmts, _, err := p.Parse("SELECT created_at > '2023-10-01 08:30:00' FROM test.orders", "", "")
+		assert.NoError(t, err)
+		assert.Len(t, stmts, 1)
+		// Build logical plan without optimization
+		plan1, _, err := BuildLogicalPlan(context.Background(), sctx, stmts[0], is)
+		assert.NoError(t, err)
+		assert.NotNil(t, plan1)
+		lp1, ok := plan1.(LogicalPlan)
+		assert.True(t, ok)
+		// Find constants in the non-optimized plan
+		constants1 := findConstantsInPlan(lp1)
+		assert.GreaterOrEqual(t, len(constants1), 1)
+		if len(constants1) > 0 {
+			assert.Equal(t, "2023-10-01 08:30:00", constants1[0].Value.GetString())
+		}
+		// Build logical plan with optimization
+		plan2, _, err := BuildLogicalPlanWithOptimization(context.Background(), sctx, stmts[0], is)
+		assert.NoError(t, err)
+		assert.NotNil(t, plan2)
+		// Find constants in the optimized plan
+		constants2 := findConstantsInPlan(plan2)
+		assert.GreaterOrEqual(t, len(constants2), 1)
+		if len(constants2) > 0 {
+			assert.Equal(t, "2023-10-01 08:30:00+08:00", constants2[0].Value.GetString())
+		}
+	})
+	// Test case 6: Timestamp literals in aggregation expressions
+	t.Run("TimestampLiteralsInAggregation", func(t *testing.T) {
+		p := parser.New()
+		stmts, _, err := p.Parse("SELECT SUM(IF(created_at > '2023-10-01 08:30:00', 1, 0.5)) FROM test.orders", "", "")
+		assert.NoError(t, err)
+		assert.Len(t, stmts, 1)
+		// Build logical plan without optimization
+		plan1, _, err := BuildLogicalPlan(context.Background(), sctx, stmts[0], is)
+		assert.NoError(t, err)
+		assert.NotNil(t, plan1)
+		lp1, ok := plan1.(LogicalPlan)
+		assert.True(t, ok)
+		// Find constants in the non-optimized plan
+		constants1 := findConstantsInPlan(lp1)
+		assert.GreaterOrEqual(t, len(constants1), 1)
+		if len(constants1) > 0 {
+			assert.Equal(t, "2023-10-01 08:30:00", constants1[0].Value.GetString())
+		}
+		// Build logical plan with optimization
+		plan2, _, err := BuildLogicalPlanWithOptimization(context.Background(), sctx, stmts[0], is)
+		assert.NoError(t, err)
+		assert.NotNil(t, plan2)
+		// Find constants in the optimized plan
+		constants2 := findConstantsInPlan(plan2)
+		assert.GreaterOrEqual(t, len(constants2), 1)
+		if len(constants2) > 0 {
+			assert.Equal(t, "2023-10-01 08:30:00+08:00", constants2[0].Value.GetString())
+		}
+	})
+	// Test case 7: Timestamp literals in GROUP BY with time comparisons
+	t.Run("TimestampLiteralsInGroupByWithComparisons", func(t *testing.T) {
+		p := parser.New()
+		stmts, _, err := p.Parse("SELECT COUNT(*) FROM test.orders GROUP BY created_at > '2023-10-01 08:30:00'", "", "")
+		assert.NoError(t, err)
+		assert.Len(t, stmts, 1)
+		// Build logical plan without optimization
+		plan1, _, err := BuildLogicalPlan(context.Background(), sctx, stmts[0], is)
+		assert.NoError(t, err)
+		assert.NotNil(t, plan1)
+		lp1, ok := plan1.(LogicalPlan)
+		assert.True(t, ok)
+		// Find constants in the non-optimized plan
+		constants1 := findConstantsInPlan(lp1)
+		assert.GreaterOrEqual(t, len(constants1), 1)
+		if len(constants1) > 0 {
+			assert.Equal(t, "2023-10-01 08:30:00", constants1[0].Value.GetString())
+		}
+		// Build logical plan with optimization
+		plan2, _, err := BuildLogicalPlanWithOptimization(context.Background(), sctx, stmts[0], is)
+		assert.NoError(t, err)
+		assert.NotNil(t, plan2)
+		// Find constants in the optimized plan
+		constants2 := findConstantsInPlan(plan2)
+		assert.GreaterOrEqual(t, len(constants2), 1)
+		if len(constants2) > 0 {
+			assert.Equal(t, "2023-10-01 08:30:00+08:00", constants2[0].Value.GetString())
+		}
+	})
+	// Test case 8: Timestamp literals in window functions
+	t.Run("TimestampLiteralsInWindowFunctions", func(t *testing.T) {
+		p := parser.New()
+		stmts, _, err := p.Parse("SELECT created_at, ROW_NUMBER() OVER (PARTITION BY created_at > '2023-10-01 08:30:00' ORDER BY created_at) as rn FROM test.orders", "", "")
+		assert.NoError(t, err)
+		assert.Len(t, stmts, 1)
+		// Build logical plan without optimization
+		plan1, _, err := BuildLogicalPlan(context.Background(), sctx, stmts[0], is)
+		assert.NoError(t, err)
+		assert.NotNil(t, plan1)
+		lp1, ok := plan1.(LogicalPlan)
+		assert.True(t, ok)
+		// Find constants in the non-optimized plan
+		constants1 := findConstantsInPlan(lp1)
+		assert.GreaterOrEqual(t, len(constants1), 1)
+		if len(constants1) > 0 {
+			assert.Equal(t, "2023-10-01 08:30:00", constants1[0].Value.GetString())
+		}
+		// Build logical plan with optimization
+		plan2, _, err := BuildLogicalPlanWithOptimization(context.Background(), sctx, stmts[0], is)
+		assert.NoError(t, err)
+		assert.NotNil(t, plan2)
+		// Find constants in the optimized plan
+		constants2 := findConstantsInPlan(plan2)
+		assert.GreaterOrEqual(t, len(constants2), 1)
+		if len(constants2) > 0 {
+			assert.Equal(t, "2023-10-01 08:30:00+08:00", constants2[0].Value.GetString())
+		}
+	})
+	// Test case 9: Timestamp literals in ORDER BY clauses
+	t.Run("TimestampLiteralsInOrderBy", func(t *testing.T) {
+		p := parser.New()
+		stmts, _, err := p.Parse("SELECT created_at FROM test.orders ORDER BY (created_at > '2023-10-01 08:30:00') DESC", "", "")
+		assert.NoError(t, err)
+		assert.Len(t, stmts, 1)
+		// Build logical plan without optimization
+		plan1, _, err := BuildLogicalPlan(context.Background(), sctx, stmts[0], is)
+		assert.NoError(t, err)
+		assert.NotNil(t, plan1)
+		lp1, ok := plan1.(LogicalPlan)
+		assert.True(t, ok)
+		// Find constants in the non-optimized plan
+		constants1 := findConstantsInPlan(lp1)
+		assert.GreaterOrEqual(t, len(constants1), 1)
+		if len(constants1) > 0 {
+			assert.Equal(t, "2023-10-01 08:30:00", constants1[0].Value.GetString())
+		}
+		// Build logical plan with optimization
+		plan2, _, err := BuildLogicalPlanWithOptimization(context.Background(), sctx, stmts[0], is)
+		assert.NoError(t, err)
+		assert.NotNil(t, plan2)
+		// Find constants in the optimized plan
+		constants2 := findConstantsInPlan(plan2)
+		assert.GreaterOrEqual(t, len(constants2), 1)
+		if len(constants2) > 0 {
+			assert.Equal(t, "2023-10-01 08:30:00+08:00", constants2[0].Value.GetString())
+		}
+	})
+	// Test case 10: Timestamp literals in subquery with APPLY
+	t.Run("TimestampLiteralsInApply", func(t *testing.T) {
+		p := parser.New()
+		stmts, _, err := p.Parse("SELECT (SELECT COUNT(*) FROM test.orders o2 WHERE o2.created_at > '2023-10-01 08:30:00' AND o2.status = o1.status) FROM test.orders o1", "", "")
+		assert.NoError(t, err)
+		assert.Len(t, stmts, 1)
+		// Build logical plan without optimization
+		plan1, _, err := BuildLogicalPlan(context.Background(), sctx, stmts[0], is)
+		assert.NoError(t, err)
+		assert.NotNil(t, plan1)
+		lp1, ok := plan1.(LogicalPlan)
+		assert.True(t, ok)
+		// Find constants in the non-optimized plan
+		constants1 := findConstantsInPlan(lp1)
+		assert.GreaterOrEqual(t, len(constants1), 1)
+		if len(constants1) > 0 {
+			assert.Equal(t, "2023-10-01 08:30:00", constants1[0].Value.GetString())
+		}
+		// Build logical plan with optimization
+		plan2, _, err := BuildLogicalPlanWithOptimization(context.Background(), sctx, stmts[0], is)
+		assert.NoError(t, err)
+		assert.NotNil(t, plan2)
+		// Find constants in the optimized plan
+		constants2 := findConstantsInPlan(plan2)
+		assert.GreaterOrEqual(t, len(constants2), 1)
+		if len(constants2) > 0 {
+			assert.Equal(t, "2023-10-01 08:30:00+08:00", constants2[0].Value.GetString())
+		}
+	})
+}
+
+// findConstantsInPlan recursively traverses a logical plan and collects all constant expressions
+func findConstantsInPlan(lp LogicalPlan) []*expression.Constant {
+	var constants []*expression.Constant
+	switch node := lp.(type) {
+	case *LogicalSelection:
+		for _, expr := range node.Conditions {
+			constants = append(constants, findConstantsInExpression(expr)...)
+		}
+	case *LogicalProjection:
+		for _, expr := range node.Exprs {
+			constants = append(constants, findConstantsInExpression(expr)...)
+		}
+	case *LogicalAggregation:
+		// Process aggregation function arguments and group by items
+		for _, aggFunc := range node.AggFuncs {
+			for _, arg := range aggFunc.Args {
+				constants = append(constants, findConstantsInExpression(arg)...)
+			}
+		}
+		for _, item := range node.GroupByItems {
+			constants = append(constants, findConstantsInExpression(item)...)
+		}
+	case *LogicalWindow:
+		// Process window function arguments, partition by, order by, and frame bounds
+		for _, windowFunc := range node.WindowFuncDescs {
+			for _, arg := range windowFunc.Args {
+				constants = append(constants, findConstantsInExpression(arg)...)
+			}
+		}
+		for _, item := range node.PartitionBy {
+			constants = append(constants, findConstantsInExpression(item.Col)...)
+		}
+		for _, item := range node.OrderBy {
+			constants = append(constants, findConstantsInExpression(item.Col)...)
+		}
+		// Process frame bound expressions if they exist
+		if node.Frame != nil {
+			if node.Frame.Start != nil {
+				for _, calcFunc := range node.Frame.Start.CalcFuncs {
+					constants = append(constants, findConstantsInExpression(calcFunc)...)
+				}
+			}
+			if node.Frame.End != nil {
+				for _, calcFunc := range node.Frame.End.CalcFuncs {
+					constants = append(constants, findConstantsInExpression(calcFunc)...)
+				}
+			}
+		}
+	case *LogicalSort:
+		// Process sort expressions
+		for _, item := range node.ByItems {
+			constants = append(constants, findConstantsInExpression(item.Expr)...)
+		}
+	case *LogicalApply:
+		// Process correlated columns
+		for _, col := range node.CorCols {
+			constants = append(constants, findConstantsInExpression(&col.Column)...)
+		}
+		// Process all join conditions
+		for _, eqCond := range node.EqualConditions {
+			constants = append(constants, findConstantsInExpression(eqCond)...)
+		}
+		for _, leftCond := range node.LeftConditions {
+			constants = append(constants, findConstantsInExpression(leftCond)...)
+		}
+		for _, rightCond := range node.RightConditions {
+			constants = append(constants, findConstantsInExpression(rightCond)...)
+		}
+		for _, otherCond := range node.OtherConditions {
+			constants = append(constants, findConstantsInExpression(otherCond)...)
+		}
+	}
+	// Recursively process children
+	for _, child := range lp.Children() {
+		constants = append(constants, findConstantsInPlan(child)...)
+	}
+	return constants
+}
+
+// findConstantsInExpression recursively traverses an expression and collects all constant expressions
+func findConstantsInExpression(expr expression.Expression) []*expression.Constant {
+	var constants []*expression.Constant
+	if constant, ok := expr.(*expression.Constant); ok {
+		// Only include constants that match timestamp formats
+		if constant.Value.Kind() == types.KindString {
+			strValue := constant.Value.GetString()
+			// Check if it matches timestamp pattern like "2023-10-01 08:30:00" or "2023-10-01T08:30:00"
+			timestampPattern := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}`)
+			if timestampPattern.MatchString(strValue) {
+				constants = append(constants, constant)
+			}
+		}
+	}
+	if scalarFunc, ok := expr.(*expression.ScalarFunction); ok {
+		for _, arg := range scalarFunc.GetArgs() {
+			constants = append(constants, findConstantsInExpression(arg)...)
+		}
+	}
+	return constants
+}

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -101,6 +101,9 @@ type SessionVars struct {
 
 	// GroupByThreshold applied to protect query results
 	GroupByThreshold uint64
+
+	// CreatedAt is the time when the session is created
+	CreatedAt time.Time
 }
 
 // PreparedParams contains the parameters of the current prepared statement when executing it.

--- a/pkg/util/mock/mock_data.go
+++ b/pkg/util/mock/mock_data.go
@@ -23,6 +23,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"gorm.io/gorm"
 
@@ -301,6 +302,7 @@ func MockAllTables() (map[string][]*model.TableInfo, error) {
 func MockContext() sessionctx.Context {
 	ctx := sessionctx.NewContext()
 	ctx.GetSessionVars().CurrentDB = "test"
+	ctx.GetSessionVars().CreatedAt = time.Date(2023, 10, 1, 8, 30, 0, 0, time.FixedZone("UTC+8", 8*3600))
 	return ctx
 }
 


### PR DESCRIPTION
新增 timestamp 字面量优化器，自动为 timestamp 字面量添加时区信息，没有设置时区的 timestamp 数据会使用 compile 时传入的时区。