### PR TITLE
chore: fix syntax in regtest-config.yml

### DIFF
--- a/.circleci/regtest-config.yml
+++ b/.circleci/regtest-config.yml
@@ -58,7 +58,7 @@ jobs:
             mkdir -p "${DIR}"
             BINARIES="engine/exe/scqlengine:scqlengine bin/scdbserver:scdbserver bin/scdbclient:scdbclient bin/broker:broker bin/brokerctl:brokerctl bin/agent:agent"
             for item in $BINARIES; do
-              IFS=':' read -r src dest \<<< "$item"
+              src="${item%%:*}"; dest="${item#*:}"
               cp "bazel-bin/${src}" "${DIR}/${dest}"
             done
       - persist_to_workspace:


### PR DESCRIPTION
'<<' must be escaped as '\\<<' in config v2.1+