### PR TITLE
fix: handle empty input in UnquoteChar

### DIFF
--- a/pkg/util/stringutil/string_util.go
+++ b/pkg/util/stringutil/string_util.go
@@ -47,6 +47,10 @@ var ErrSyntax = errors.New("invalid syntax")
 // If set to zero, it does not permit either escape and allows both quote characters to appear unescaped.
 // Different with strconv.UnquoteChar, it permits unnecessary backslash.
 func UnquoteChar(s string, quote byte) (value []byte, tail string, err error) {
+	if len(s) == 0 {
+		return nil, "", errors.Trace(ErrSyntax)
+	}
+
 	// easy cases
 	switch c := s[0]; {
 	case c == quote:

--- a/pkg/util/stringutil/string_util_test.go
+++ b/pkg/util/stringutil/string_util_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/secretflow/scql/pkg/util/testleak"
@@ -38,7 +39,7 @@ func (s *testStringUtilSuite) TestUnquoteCharEmptyInput(c *C) {
 	value, tail, err := UnquoteChar("", '\'')
 	c.Assert(value, IsNil)
 	c.Assert(tail, Equals, "")
-	c.Assert(err, NotNil)
+	c.Assert(errors.Cause(err), Equals, ErrSyntax)
 }
 
 func (s *testStringUtilSuite) TestUnquote(c *C) {

--- a/pkg/util/stringutil/string_util_test.go
+++ b/pkg/util/stringutil/string_util_test.go
@@ -32,6 +32,15 @@ var _ = Suite(&testStringUtilSuite{})
 type testStringUtilSuite struct {
 }
 
+func (s *testStringUtilSuite) TestUnquoteCharEmptyInput(c *C) {
+	defer testleak.AfterTest(c)()
+
+	value, tail, err := UnquoteChar("", '\'')
+	c.Assert(value, IsNil)
+	c.Assert(tail, Equals, "")
+	c.Assert(err, NotNil)
+}
+
 func (s *testStringUtilSuite) TestUnquote(c *C) {
 	defer testleak.AfterTest(c)()
 	table := []struct {


### PR DESCRIPTION
## What this PR does

Return `ErrSyntax` when `UnquoteChar` receives an empty string instead of indexing `s[0]` and panicking.

## Testing

- `go test ./pkg/util/stringutil`

A regression test covers the empty-input case and verifies that the function returns an error with empty value and tail results.