### PR TITLE
fix: correct separate spelling in service logs

### DIFF
--- a/engine/exe/main.cc
+++ b/engine/exe/main.cc
@@ -456,14 +456,14 @@ int main(int argc, char* argv[]) {
       return -1;
     }
   } else {
-    SPDLOG_INFO("Adding MuxReceiverService into seperate link server...");
+    SPDLOG_INFO("Adding MuxReceiverService into separate link server...");
     if (link_svr.AddService(&rcv_svc, brpc::SERVER_DOESNT_OWN_SERVICE) != 0) {
-      SPDLOG_ERROR("Fail to add MuxReceiverService to seperate link server");
+      SPDLOG_ERROR("Fail to add MuxReceiverService to separate link server");
       return -1;
     }
-    SPDLOG_INFO("Adding ErrorCollectorService into seperate link server...");
+    SPDLOG_INFO("Adding ErrorCollectorService into separate link server...");
     if (link_svr.AddService(&err_svc, brpc::SERVER_DOESNT_OWN_SERVICE) != 0) {
-      SPDLOG_ERROR("Fail to add ErrorCollectorService to seperate link server");
+      SPDLOG_ERROR("Fail to add ErrorCollectorService to separate link server");
       return -1;
     }
   }


### PR DESCRIPTION
## Summary

Correct the spelling of `separate` in MuxReceiverService and ErrorCollectorService log messages.

## Problem

The service startup and error logs currently say `seperate link server`, which is misspelled and appears in user-visible operational output.

## Changes

- Replace all four occurrences in `engine/exe/main.cc` with `separate link server`.

## Verification

- Base SHA: `$(git rev-parse main)`.
- Confirmed four occurrences on current main via repository search.
- `git diff --check` passed.
- Full build/tests unavailable because this environment lacks the repository's Bazel/Go toolchains; CI should validate compilation.

## Risk

Logging text only; no behavior or API changes.

AI-assisted contribution; implementation and verification performed against current main.