### PR TITLE
docs: clarify test CA security guidance

### DIFF
--- a/test-tools/README.md
+++ b/test-tools/README.md
@@ -2,7 +2,7 @@
 
 If you want to enable tls in SCQL but don't have existing CA files, ca_generator.sh can help to generate self-signed CA files.
 
-``NOTE``: Self-signed CA files are ``not safe`` and can only be used for testing. Considering security, commercial CA files must be used in production environments.
+``NOTE``: Self-signed CA files are ``not safe`` and can only be used for testing. For security reasons, commercial CA files must be used in production environments.
 
 ## Step 1
 


### PR DESCRIPTION
## Summary

Clarify the security guidance for self-signed CA files in the test-tools README.

## Problem

The sentence `Considering security, commercial CA files must be used in production environments` is grammatically awkward and less clear for readers.

## Changes

- Replace it with `For security reasons, commercial CA files must be used in production environments.`

## Verification

- Base SHA: `$(git rev-parse main)`.
- Confirmed the original wording in current main before editing.
- `git diff --check` passed.
- Documentation-only change; no code build required.

## Risk

No runtime impact; this makes existing security guidance clearer without changing its meaning.

AI-assisted contribution; implementation and verification performed against current main.